### PR TITLE
fix: kubectl apply in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ kubectl -n csi-proxmox create secret generic proxmox-csi-plugin --from-file=conf
 Latest stable version (edge)
 
 ```shell
-kubectl -f https://raw.githubusercontent.com/sergelogvinov/proxmox-csi-plugin/main/docs/deploy/proxmox-csi-plugin.yml
+kubectl apply -f https://raw.githubusercontent.com/sergelogvinov/proxmox-csi-plugin/main/docs/deploy/proxmox-csi-plugin.yml
 ```
 
 ### Method 2: By Helm
@@ -142,7 +142,7 @@ cluster:
 Deploy the pod
 
 ```shell
-kubectl -f https://raw.githubusercontent.com/sergelogvinov/proxmox-csi-plugin/main/docs/deploy/test-pod-ephemeral.yaml
+kubectl apply -f https://raw.githubusercontent.com/sergelogvinov/proxmox-csi-plugin/main/docs/deploy/test-pod-ephemeral.yaml
 ```
 
 Check status of PV,PVC
@@ -188,7 +188,7 @@ Source:
 ### Statefulset with persistent storage
 
 ```shell
-kubectl -f https://raw.githubusercontent.com/sergelogvinov/proxmox-csi-plugin/main/docs/deploy/test-statefulset.yaml
+kubectl apply -f https://raw.githubusercontent.com/sergelogvinov/proxmox-csi-plugin/main/docs/deploy/test-statefulset.yaml
 ```
 
 Check status of PV,PVC


### PR DESCRIPTION
# Pull Request

## What?

Bad `kubectl` command in the readme

## Why? (reasoning)

Apply is missing to deploy manifests

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)
