### PR TITLE
Skip non-qemu VMs when expanding volumes

### DIFF
--- a/pkg/csi/controller.go
+++ b/pkg/csi/controller.go
@@ -488,6 +488,12 @@ func (d *ControllerService) ControllerExpandVolume(_ context.Context, request *c
 			return nil, status.Errorf(codes.Internal, "failed to cast response to map, vm: %v", vm)
 		}
 
+		if vm["type"].(string) != "qemu" {
+			klog.V(4).Infof("skipping non-qemu VM %s", vm["name"].(string))
+
+			continue
+		}
+
 		if vm["node"].(string) == vol.Node() {
 			vmID := int(vm["vmid"].(float64))
 


### PR DESCRIPTION
# Pull Request

First of, thank you for this great project, I've been very happy with it.

## What? (description)

Skip non-QEMU (LXC) VMs when iterating over VMs when expanding volumes.

## Why? (reasoning)

The controller loops through all VMs when expanding volumes and faces issues when processing LXC VMs. This PR skips them.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
