### PR TITLE
feat: regional block devices

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         source: ./
         target: /src
   csi-attacher:
-    image: registry.k8s.io/sig-storage/csi-attacher:v4.2.0
+    image: registry.k8s.io/sig-storage/csi-attacher:v4.3.0
     network_mode: "service:base"
     command:
       - "--v=5"
@@ -40,7 +40,7 @@ services:
         source: ./hack
         target: /etc/kubernetes
   csi-resizer:
-    image: registry.k8s.io/sig-storage/csi-resizer:v1.7.0
+    image: registry.k8s.io/sig-storage/csi-resizer:v1.8.0
     network_mode: "service:base"
     command:
       - "--v=5"
@@ -56,7 +56,7 @@ services:
         source: ./hack
         target: /etc/kubernetes
   csi-provisioner:
-    image: registry.k8s.io/sig-storage/csi-provisioner:v3.4.0
+    image: registry.k8s.io/sig-storage/csi-provisioner:v3.5.0
     network_mode: "service:base"
     command:
       - "--v=5"

--- a/docs/deploy/test-pod-ephemeral.yaml
+++ b/docs/deploy/test-pod-ephemeral.yaml
@@ -7,8 +7,8 @@ spec:
   tolerations:
     - effect: NoSchedule
       key: node-role.kubernetes.io/control-plane
-  # nodeSelector:
-  #    kubernetes.io/hostname: worker-11
+  nodeSelector:
+    kubernetes.io/hostname: kube-11
   containers:
     - name: alpine
       image: alpine
@@ -38,7 +38,7 @@ spec:
               type: pvc-volume
           spec:
             accessModes: [ "ReadWriteOnce" ]
-            storageClassName: proxmox-data-xfs
+            storageClassName: proxmox-rbd
             resources:
               requests:
                 storage: 1Gi

--- a/docs/deploy/test-statefulset.yaml
+++ b/docs/deploy/test-statefulset.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   podManagementPolicy: Parallel  # default is OrderedReady
   serviceName: test
-  replicas: 4
+  replicas: 1
   template:
     metadata:
       labels:
@@ -18,8 +18,9 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane
-      # nodeSelector:
-      #   topology.kubernetes.io/zone: worker-metal-1
+      nodeSelector:
+        # kubernetes.io/hostname: kube-21
+        # topology.kubernetes.io/zone: hvm-1
       containers:
         - name: alpine
           image: alpine
@@ -45,4 +46,4 @@ spec:
         resources:
           requests:
             storage: 1Gi
-        storageClassName: proxmox-data
+        storageClassName: proxmox-rbd

--- a/docs/proxmox-lvm.yaml
+++ b/docs/proxmox-lvm.yaml
@@ -1,0 +1,11 @@
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: proxmox-lvm
+parameters:
+  csi.storage.k8s.io/fstype: xfs
+  storage: lvm
+provisioner: csi.proxmox.sinextra.dev
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/docs/proxmox-rbd.yaml
+++ b/docs/proxmox-rbd.yaml
@@ -1,0 +1,11 @@
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: proxmox-rbd
+parameters:
+  csi.storage.k8s.io/fstype: xfs
+  storage: rbd
+provisioner: csi.proxmox.sinextra.dev
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/pkg/csi/utils.go
+++ b/pkg/csi/utils.go
@@ -107,9 +107,10 @@ func waitForVolumeDetach(_ *pxapi.Client, _ *pxapi.VmRef, _ int) error {
 }
 
 func createVolume(cl *pxapi.Client, vol *volume.Volume, sizeGB int) error {
+	filename := strings.Split(vol.Disk(), "/")
 	diskParams := map[string]interface{}{
 		"vmid":     vmID,
-		"filename": vol.Disk(),
+		"filename": filename[len(filename)-1],
 		"size":     fmt.Sprintf("%dG", sizeGB),
 	}
 

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -46,7 +46,7 @@ func NewVolumeFromVolumeID(volume string) (*Volume, error) {
 }
 
 func parseVolumeID(vol string) (*Volume, error) {
-	parts := strings.Split(vol, "/")
+	parts := strings.SplitN(vol, "/", 4)
 	if len(parts) != 4 {
 		return nil, fmt.Errorf("VolumeID must be in the format of region/zone/storageName/diskName")
 	}

--- a/pkg/volume/volume_test.go
+++ b/pkg/volume/volume_test.go
@@ -48,6 +48,16 @@ func TestNewVolumeFromVolumeID(t *testing.T) {
 	assert.Equal(t, "disk", v.Disk())
 }
 
+func TestNewVolumeFromVolumeIDWithFolder(t *testing.T) {
+	v, err := volume.NewVolumeFromVolumeID("region/zone/storage/folder/disk")
+	assert.Nil(t, err)
+	assert.NotNil(t, v)
+	assert.Equal(t, "region", v.Cluster())
+	assert.Equal(t, "zone", v.Node())
+	assert.Equal(t, "storage", v.Storage())
+	assert.Equal(t, "folder/disk", v.Disk())
+}
+
 func TestNewVolumeFromVolumeIDError(t *testing.T) {
 	_, err := volume.NewVolumeFromVolumeID("region/storage/disk")
 	assert.NotNil(t, err)


### PR DESCRIPTION
Support shared block devices.
If storage is shared, PVC will have only regional affinity.

type of storages https://pve.proxmox.com/wiki/Storage
not all shared storage can be attached to the VM.

refs #60 #58 

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
