### PR TITLE
feat(chart): make StorageClass parameters/mountOptions configurable

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -27,6 +27,7 @@ policies:
         scopes:
           - deps
           - main
+          - chart
         descriptionLength: 72
   - type: license
     spec:

--- a/charts/proxmox-csi-plugin/Chart.yaml
+++ b/charts/proxmox-csi-plugin/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.10
+version: 0.1.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/proxmox-csi-plugin/templates/storageclass.yaml
+++ b/charts/proxmox-csi-plugin/templates/storageclass.yaml
@@ -1,20 +1,28 @@
+{{- define "storageClass.parameters" -}}
+csi.storage.k8s.io/fstype: {{ default "ext4" .fstype }}
+storage: {{ .storage | required "Proxmox Storage name must be provided." }}
+{{- with .cache }}
+cache: {{ . }}
+{{- end }}
+{{- if .ssd }}
+ssd: "true"
+{{- end }}
+{{- end }}
+
 {{- range $storage := .Values.storageClass }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ $storage.name }}
+  name: {{ $storage.name | required "StorageClass name must be provided." }}
 provisioner: {{ $.Values.provisionerName }}
 allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: {{ default "Delete" $storage.reclaimPolicy }}
 parameters:
-  csi.storage.k8s.io/fstype: {{ default "ext4" $storage.fstype }}
-  storage: {{ $storage.storage }}
-  {{- if $storage.cache }}
-  cache: {{  $storage.cache }}
-  {{- end }}
-  {{- if $storage.ssd }}
-  ssd: "true"
-  {{- end }}
+  {{- mustMergeOverwrite (default (dict) $storage.extraParameters) (include "storageClass.parameters" . | fromYaml) | toYaml | nindent 2 -}}
+{{- with $storage.mountOptions }}
+mountOptions:
+  {{- . | toYaml | nindent 2 }}
+{{- end }}
 ---
 {{- end }}

--- a/charts/proxmox-csi-plugin/values.yaml
+++ b/charts/proxmox-csi-plugin/values.yaml
@@ -68,6 +68,14 @@ storageClass: []
   #   # https://pve.proxmox.com/wiki/Performance_Tweaks
   #   cache: directsync|none|writeback|writethrough
   #   ssd: true
+  #   extraParameters:
+  #     # https://kubernetes-csi.github.io/docs/secrets-and-credentials-storage-class.html
+  #     csi.storage.k8s.io/node-stage-secret-name: "proxmox-csi-secret"
+  #     csi.storage.k8s.io/node-stage-secret-namespace: "kube-system"
+  #     csi.storage.k8s.io/node-expand-secret-name: "proxmox-csi-secret"
+  #     csi.storage.k8s.io/node-expand-secret-namespace: "kube-system"
+  #   mountOptions:
+  #     - discard
 
 controller:
   plugin:


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)
This will allow the user to optionally define extra `parameters` and `mountOptions` for the provisioned `StorageClass`, without having to template it outside of the chart. Existing behaviour is unchanged[1] and pre-existing parameters like `cache`, `ssd` will have priority over what the user defines. 

[1] I've added 2 small error messages, for rare cases where the user might forget to fill out `.name` or `.storage`.

## Why? (reasoning)
Convenience. With this change it's just another 2 lines to for example enable the `discard` mount option or to add the required parameters for encryption.
 
## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
