### PR TITLE
fix(chart): detect safe mounted behavior

### DIFF
--- a/charts/proxmox-csi-plugin/Chart.yaml
+++ b/charts/proxmox-csi-plugin/Chart.yaml
@@ -16,7 +16,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.17
+version: 0.1.18
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/proxmox-csi-plugin/README.md
+++ b/charts/proxmox-csi-plugin/README.md
@@ -1,6 +1,6 @@
 # proxmox-csi-plugin
 
-![Version: 0.1.17](https://img.shields.io/badge/Version-0.1.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.1](https://img.shields.io/badge/AppVersion-v0.4.1-informational?style=flat-square)
+![Version: 0.1.18](https://img.shields.io/badge/Version-0.1.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.1](https://img.shields.io/badge/AppVersion-v0.4.1-informational?style=flat-square)
 
 A CSI plugin for Proxmox
 

--- a/charts/proxmox-csi-plugin/templates/node-deployment.yaml
+++ b/charts/proxmox-csi-plugin/templates/node-deployment.yaml
@@ -41,7 +41,6 @@ spec:
               - SYS_ADMIN
               - CHOWN
               - DAC_OVERRIDE
-            readOnlyRootFilesystem: true
             seccompProfile:
               type: RuntimeDefault
           image: "{{ .Values.node.plugin.image.repository }}:{{ .Values.node.plugin.image.tag | default .Chart.AppVersion }}"

--- a/docs/deploy/proxmox-csi-plugin-release.yml
+++ b/docs/deploy/proxmox-csi-plugin-release.yml
@@ -16,7 +16,7 @@ metadata:
   name: proxmox-csi-plugin-controller
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.1.17
+    helm.sh/chart: proxmox-csi-plugin-0.1.18
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.4.1"
@@ -29,7 +29,7 @@ metadata:
   name: proxmox-csi-plugin-node
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.1.17
+    helm.sh/chart: proxmox-csi-plugin-0.1.18
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.4.1"
@@ -42,7 +42,7 @@ metadata:
   name: proxmox-csi-plugin-controller
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.1.17
+    helm.sh/chart: proxmox-csi-plugin-0.1.18
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.4.1"
@@ -85,7 +85,7 @@ metadata:
   name: proxmox-csi-plugin-node
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.1.17
+    helm.sh/chart: proxmox-csi-plugin-0.1.18
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.4.1"
@@ -133,7 +133,7 @@ metadata:
   name: proxmox-csi-plugin-controller
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.1.17
+    helm.sh/chart: proxmox-csi-plugin-0.1.18
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.4.1"
@@ -175,7 +175,7 @@ metadata:
   name: proxmox-csi-plugin-node
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.1.17
+    helm.sh/chart: proxmox-csi-plugin-0.1.18
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.4.1"
@@ -212,7 +212,6 @@ spec:
               - SYS_ADMIN
               - CHOWN
               - DAC_OVERRIDE
-            readOnlyRootFilesystem: true
             seccompProfile:
               type: RuntimeDefault
           image: "ghcr.io/sergelogvinov/proxmox-csi-node:v0.4.1"
@@ -319,7 +318,7 @@ metadata:
   name: proxmox-csi-plugin-controller
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.1.17
+    helm.sh/chart: proxmox-csi-plugin-0.1.18
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.4.1"

--- a/docs/deploy/proxmox-csi-plugin-talos.yml
+++ b/docs/deploy/proxmox-csi-plugin-talos.yml
@@ -16,7 +16,7 @@ metadata:
   name: proxmox-csi-plugin-controller
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.1.17
+    helm.sh/chart: proxmox-csi-plugin-0.1.18
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.4.1"
@@ -29,7 +29,7 @@ metadata:
   name: proxmox-csi-plugin-node
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.1.17
+    helm.sh/chart: proxmox-csi-plugin-0.1.18
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.4.1"
@@ -68,7 +68,7 @@ metadata:
   name: proxmox-csi-plugin-controller
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.1.17
+    helm.sh/chart: proxmox-csi-plugin-0.1.18
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.4.1"
@@ -111,7 +111,7 @@ metadata:
   name: proxmox-csi-plugin-node
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.1.17
+    helm.sh/chart: proxmox-csi-plugin-0.1.18
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.4.1"
@@ -159,7 +159,7 @@ metadata:
   name: proxmox-csi-plugin-controller
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.1.17
+    helm.sh/chart: proxmox-csi-plugin-0.1.18
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.4.1"
@@ -201,7 +201,7 @@ metadata:
   name: proxmox-csi-plugin-node
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.1.17
+    helm.sh/chart: proxmox-csi-plugin-0.1.18
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.4.1"
@@ -238,7 +238,6 @@ spec:
               - SYS_ADMIN
               - CHOWN
               - DAC_OVERRIDE
-            readOnlyRootFilesystem: true
             seccompProfile:
               type: RuntimeDefault
           image: "ghcr.io/sergelogvinov/proxmox-csi-node:v0.4.1"
@@ -342,7 +341,7 @@ metadata:
   name: proxmox-csi-plugin-controller
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.1.17
+    helm.sh/chart: proxmox-csi-plugin-0.1.18
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.4.1"

--- a/docs/deploy/proxmox-csi-plugin.yml
+++ b/docs/deploy/proxmox-csi-plugin.yml
@@ -16,7 +16,7 @@ metadata:
   name: proxmox-csi-plugin-controller
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.1.17
+    helm.sh/chart: proxmox-csi-plugin-0.1.18
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.4.1"
@@ -29,7 +29,7 @@ metadata:
   name: proxmox-csi-plugin-node
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.1.17
+    helm.sh/chart: proxmox-csi-plugin-0.1.18
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.4.1"
@@ -69,7 +69,7 @@ metadata:
   name: proxmox-csi-plugin-controller
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.1.17
+    helm.sh/chart: proxmox-csi-plugin-0.1.18
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.4.1"
@@ -112,7 +112,7 @@ metadata:
   name: proxmox-csi-plugin-node
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.1.17
+    helm.sh/chart: proxmox-csi-plugin-0.1.18
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.4.1"
@@ -160,7 +160,7 @@ metadata:
   name: proxmox-csi-plugin-controller
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.1.17
+    helm.sh/chart: proxmox-csi-plugin-0.1.18
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.4.1"
@@ -202,7 +202,7 @@ metadata:
   name: proxmox-csi-plugin-node
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.1.17
+    helm.sh/chart: proxmox-csi-plugin-0.1.18
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.4.1"
@@ -239,7 +239,6 @@ spec:
               - SYS_ADMIN
               - CHOWN
               - DAC_OVERRIDE
-            readOnlyRootFilesystem: true
             seccompProfile:
               type: RuntimeDefault
           image: "ghcr.io/sergelogvinov/proxmox-csi-node:edge"
@@ -346,7 +345,7 @@ metadata:
   name: proxmox-csi-plugin-controller
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.1.17
+    helm.sh/chart: proxmox-csi-plugin-0.1.18
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.4.1"


### PR DESCRIPTION
Error: mount_linux.go:274 Cannot create temp dir to detect safe 'not mounted' behavior: mkdir /tmp/kubelet-detect-safe-umount1647621063: read-only file system

mount_linux.go requires writable /tmp

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
