### PR TITLE
fix: allow nfs shared storages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	k8s.io/component-base v0.31.0
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/mount-utils v0.31.0
-	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
+	k8s.io/utils v0.0.0-20240821151609-f90d01438635
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ k8s.io/kube-openapi v0.0.0-20240620174524-b456828f718b h1:Q9xmGWBvOGd8UJyccgpYlL
 k8s.io/kube-openapi v0.0.0-20240620174524-b456828f718b/go.mod h1:UxDHUPsUwTOOxSU+oXURfFBcAS6JwiRXTYqYwfuGowc=
 k8s.io/mount-utils v0.31.0 h1:o+a+n6gyZ7MGc6bIERU3LeFTHbLDBiVReaDpWlJotUE=
 k8s.io/mount-utils v0.31.0/go.mod h1:HV/VYBUGqYUj4vt82YltzpWvgv8FPg0G9ItyInT3NPU=
-k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 h1:pUdcCO1Lk/tbT5ztQWOBi5HBgbBP1J8+AsQnQCKsi8A=
-k8s.io/utils v0.0.0-20240711033017-18e509b52bc8/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+k8s.io/utils v0.0.0-20240821151609-f90d01438635 h1:2wThSvJoW/Ncn9TmQEYXRnevZXi2duqHWf5OX9S3zjI=
+k8s.io/utils v0.0.0-20240821151609-f90d01438635/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=

--- a/pkg/csi/controller.go
+++ b/pkg/csi/controller.go
@@ -179,8 +179,8 @@ func (d *ControllerService) CreateVolume(_ context.Context, request *csi.CreateV
 	if storageConfig["shared"] != nil && int(storageConfig["shared"].(float64)) == 1 {
 		// https://pve.proxmox.com/wiki/Storage only block/local storage are supported
 		switch storageConfig["type"].(string) {
-		case "nfs", "cifs", "pbs":
-			return nil, status.Error(codes.Internal, "error: shared storage type nfs,cifs,pbs are not supported")
+		case "cifs", "pbs":
+			return nil, status.Error(codes.Internal, "error: shared storage type cifs, pbs are not supported")
 		}
 
 		topology = &csi.Topology{

--- a/pkg/csi/controller_test.go
+++ b/pkg/csi/controller_test.go
@@ -530,7 +530,7 @@ func (ts *csiTestSuite) TestCreateVolume() {
 					},
 				},
 			},
-			expectedError: status.Error(codes.Internal, "error: shared storage type nfs,cifs,pbs are not supported"),
+			expectedError: status.Error(codes.Internal, "error: shared storage type cifs, pbs are not supported"),
 		},
 		{
 			msg: "WrongClusterNotFound",


### PR DESCRIPTION
Remove limitation of using nfs as shared storage.

ref #157

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
