### PR TITLE
docs: fix example pvecsictl cloud-config

### DIFF
--- a/docs/pvecsictl.md
+++ b/docs/pvecsictl.md
@@ -65,6 +65,7 @@ clusters:
   - url: https://cluster-1:8006/api2/json
     username: root@pam
     password: "strong-password"
+    region: fsn1
     ...
 ```
 


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

Added region to example usage docs of pvecsictl 

## Why? (reasoning)

Using current example without region variable causes error:
```
ERROR Error: failed to read config: cluster #1: region is required
```

Adding variable fixes that error

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
