### PR TITLE
feat: minimal chunk size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:1.10
+# syntax = docker/dockerfile:1.12
 ########################################
 
 FROM golang:1.23-bookworm AS develop

--- a/pkg/csi/controller.go
+++ b/pkg/csi/controller.go
@@ -120,10 +120,9 @@ func (d *ControllerService) CreateVolume(_ context.Context, request *csi.CreateV
 		}
 	}
 
-	// Volume Size - Default is 10 GiB
-	volSizeBytes := DefaultVolumeSize * GiB
+	volSizeBytes := DefaultVolumeSizeBytes
 	if request.GetCapacityRange() != nil {
-		volSizeBytes = RoundUpSizeBytes(request.GetCapacityRange().GetRequiredBytes(), GiB)
+		volSizeBytes = RoundUpSizeBytes(request.GetCapacityRange().GetRequiredBytes(), MinChunkSizeBytes)
 	}
 
 	accessibleTopology := request.GetAccessibilityRequirements()
@@ -601,7 +600,7 @@ func (d *ControllerService) ControllerExpandVolume(_ context.Context, request *c
 		return nil, status.Error(codes.InvalidArgument, "CapacityRange must be provided")
 	}
 
-	volSizeBytes := RoundUpSizeBytes(capacityRange.GetRequiredBytes(), GiB)
+	volSizeBytes := RoundUpSizeBytes(capacityRange.GetRequiredBytes(), MinChunkSizeBytes)
 	maxVolSize := capacityRange.GetLimitBytes()
 
 	if maxVolSize > 0 && maxVolSize < volSizeBytes {

--- a/pkg/csi/controller_test.go
+++ b/pkg/csi/controller_test.go
@@ -242,7 +242,7 @@ clusters:
 				"data": []interface{}{
 					map[string]interface{}{
 						"format": "raw",
-						"size":   1024 * 1024 * 1024,
+						"size":   csi.MinChunkSizeBytes,
 						"volid":  "local-lvm:vm-9999-pvc-123",
 					},
 					map[string]interface{}{
@@ -252,7 +252,7 @@ clusters:
 					},
 					map[string]interface{}{
 						"format": "raw",
-						"size":   csi.MinVolumeSize * 1024 * 1024 * 1024,
+						"size":   csi.MinChunkSizeBytes,
 						"volid":  "local-lvm:vm-9999-pvc-exist-same-size",
 					},
 					map[string]interface{}{
@@ -579,7 +579,7 @@ func (ts *csiTestSuite) TestCreateVolume() {
 				Parameters:         volParam,
 				VolumeCapabilities: []*proto.VolumeCapability{volcap},
 				CapacityRange: &proto.CapacityRange{
-					RequiredBytes: 100,
+					RequiredBytes: 1 * csi.GiB,
 				},
 				AccessibilityRequirements: &proto.TopologyRequirement{
 					Preferred: []*proto.Topology{
@@ -616,7 +616,7 @@ func (ts *csiTestSuite) TestCreateVolume() {
 				Volume: &proto.Volume{
 					VolumeId:      "cluster-1/pve-1/local-lvm/vm-9999-pvc-exist-same-size",
 					VolumeContext: volParam,
-					CapacityBytes: int64(1024 * 1024 * 1024),
+					CapacityBytes: csi.MinChunkSizeBytes,
 					AccessibleTopology: []*proto.Topology{
 						{
 							Segments: map[string]string{
@@ -650,7 +650,7 @@ func (ts *csiTestSuite) TestCreateVolume() {
 				Volume: &proto.Volume{
 					VolumeId:      "cluster-1/pve-1/local-lvm/vm-9999-pvc-123",
 					VolumeContext: volParam,
-					CapacityBytes: int64(1024 * 1024 * 1024),
+					CapacityBytes: csi.MinChunkSizeBytes,
 					AccessibleTopology: []*proto.Topology{
 						{
 							Segments: map[string]string{

--- a/pkg/csi/driver.go
+++ b/pkg/csi/driver.go
@@ -45,10 +45,10 @@ const (
 
 	// MaxVolumesPerNode is the maximum number of volumes that can be attached to a node
 	MaxVolumesPerNode = 24
-	// MinVolumeSize is the minimum size of a volume
-	MinVolumeSize = 1 // GB
-	// DefaultVolumeSize is the default size of a volume
-	DefaultVolumeSize = 10 // GB
+	// DefaultVolumeSizeBytes is the default size of a volume
+	DefaultVolumeSizeBytes = 10 * GiB
+	// MinChunkSizeBytes is the minimum size of a volume chunk
+	MinChunkSizeBytes = 512 * MiB
 
 	// EncryptionPassphraseKey is the encryption passphrase secret key
 	EncryptionPassphraseKey = "encryption-passphrase"


### PR DESCRIPTION
Set the minimal chunk size to 512MB.
By default, XFS requires 300MB.
Additional logic will be needed if we plan to use smaller chunk sizes.

# Pull Request

#223

```
  Warning  FailedMount             90s (x9 over 3m38s)  kubelet                  MountVolume.MountDevice failed for volume "pvc-29694e9f-7d54-4145-9fc7-5af5ae1203b7" : rpc error: code = Internal desc = format of disk "/dev/sdh" failed: type:("xfs") target:("/var/lib/kubelet/plugins/kubernetes.io/csi/csi.proxmox.sinextra.dev/4a47036ef366be1a09374a7e6974afa2c19a4ee9c526aa983a9f088403055471/globalmount") options:("noatime,nouuid,defaults") errcode:(exit status 1) output:(Filesystem must be larger than 300MB.
```
<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
