### PR TITLE
feat: support different disk id

### DIFF
--- a/.github/workflows/charts.yaml
+++ b/.github/workflows/charts.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install chart-testing tools
         id: lint
-        uses: helm/chart-testing-action@v2.6.1
+        uses: helm/chart-testing-action@v2.7.0
 
       - name: Run helm chart linter
         run: ct --config hack/ct.yml lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,7 +77,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Generate token
-        uses: actions/create-github-app-token@c1a285145b9d317df6ced56c09f525b5c2b6f755 # v1.11.1
+        uses: actions/create-github-app-token@136412a57a7081aa63c935a2cc2918f76c34f514 # v1.11.2
         id: token
         with:
           app-id: "${{ secrets.BOT_APP_ID }}"

--- a/pkg/csi/controller.go
+++ b/pkg/csi/controller.go
@@ -165,7 +165,7 @@ func (d *ControllerService) CreateVolume(_ context.Context, request *csi.CreateV
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	klog.V(4).InfoS("CreateVolume", "storageConfig", storageConfig)
+	klog.V(5).InfoS("CreateVolume", "storageConfig", storageConfig)
 
 	topology := &csi.Topology{
 		Segments: map[string]string{
@@ -188,9 +188,13 @@ func (d *ControllerService) CreateVolume(_ context.Context, request *csi.CreateV
 		}
 	}
 
-	vol := volume.NewVolume(region, zone, params[StorageIDKey], fmt.Sprintf("vm-%d-%s", vmID, pvc))
+	vmr := pxapi.NewVmRef(vmID)
+	vmr.SetNode(zone)
+	vmr.SetVmType("qemu")
+
+	vol := volume.NewVolume(region, zone, params[StorageIDKey], fmt.Sprintf("vm-%d-%s", vmr.VmId(), pvc))
 	if storageConfig["path"] != nil && storageConfig["path"].(string) != "" { //nolint:errcheck
-		vol = volume.NewVolume(region, zone, params[StorageIDKey], fmt.Sprintf("%d/vm-%d-%s.raw", vmID, vmID, pvc))
+		vol = volume.NewVolume(region, zone, params[StorageIDKey], fmt.Sprintf("%d/vm-%d-%s.raw", vmr.VmId(), vmr.VmId(), pvc))
 	}
 
 	// Check if volume already exists, and use it if it has the same size, otherwise create a new one

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -98,3 +98,13 @@ func (v *Volume) Cluster() string {
 func (v *Volume) Node() string {
 	return v.zone
 }
+
+// VMID function returns the vmID in which the volume was created.
+func (v *Volume) VMID() string {
+	parts := strings.SplitN(v.disk, "-", 3)
+	if len(parts) != 3 {
+		return ""
+	}
+
+	return parts[1]
+}

--- a/pkg/volume/volume_test.go
+++ b/pkg/volume/volume_test.go
@@ -39,13 +39,14 @@ func TestNewVolume(t *testing.T) {
 }
 
 func TestNewVolumeFromVolumeID(t *testing.T) {
-	v, err := volume.NewVolumeFromVolumeID("region/zone/storage/disk")
+	v, err := volume.NewVolumeFromVolumeID("region/zone/storage/vm-1000-disk")
 	assert.Nil(t, err)
 	assert.NotNil(t, v)
 	assert.Equal(t, "region", v.Cluster())
 	assert.Equal(t, "zone", v.Node())
 	assert.Equal(t, "storage", v.Storage())
-	assert.Equal(t, "disk", v.Disk())
+	assert.Equal(t, "vm-1000-disk", v.Disk())
+	assert.Equal(t, "1000", v.VMID())
 }
 
 func TestNewVolumeFromVolumeIDWithFolder(t *testing.T) {


### PR DESCRIPTION
Now, we can work with different volume IDs (e.g., 9999) in your cluster.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

It helps to implement PV replication

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
