### PR TITLE
feat: zfs storage migration

### DIFF
--- a/pkg/csi/utils.go
+++ b/pkg/csi/utils.go
@@ -84,16 +84,23 @@ func getNodeWithStorage(cl *pxapi.Client, storageName string) (string, error) {
 }
 
 func getVMRefByVolume(cl *pxapi.Client, vol *volume.Volume) (vmr *pxapi.VmRef, err error) {
-	vmID, err := strconv.Atoi(vol.VMID())
+	id, err := strconv.Atoi(vol.VMID())
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse volume vm id: %v", err)
 	}
 
-	vmr = pxapi.NewVmRef(vmID)
+	vmr = pxapi.NewVmRef(id)
 	vmr.SetVmType("qemu")
 
 	node := vol.Node()
 	if node == "" {
+		if id != vmID {
+			_, err = cl.GetVmInfo(vmr)
+			if err == nil {
+				return vmr, nil
+			}
+		}
+
 		node, err = getNodeWithStorage(cl, vol.Storage())
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
ZFS-replicated PVs can migrate smoothly between proxmox nodes that are part of the disk replica. During migration to another zone, the pod may start slowly, as usual.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

part of #186

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
