### PR TITLE
Fix handling of empty named vms in ControllerExpandVolume

### DIFF
--- a/pkg/csi/controller.go
+++ b/pkg/csi/controller.go
@@ -716,7 +716,7 @@ func (d *ControllerService) ControllerExpandVolume(_ context.Context, request *c
 		}
 
 		if vmType, ok := vm["type"].(string); ok && vmType != "qemu" {
-			klog.V(5).InfoS("ControllerExpandVolume: skipping non-qemu VM", "VM", vm["name"].(string)) //nolint:errcheck
+			klog.V(5).InfoS("ControllerExpandVolume: skipping non-qemu VM", "VM", vm["name"]) //nolint:errcheck
 
 			continue
 		}


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

Fixes a bad type assertion on a value that could be nil. This bug crashed the controller container.

I figured out these entries were from a node that's offline. The names are unknown/null while it's down.

Logs now print "null" if the VM name is missing.

```
I0522 17:52:12.731051       1 controller.go:719] "ControllerExpandVolume: skipping non-qemu VM" VM=null
I0522 17:52:12.731079       1 controller.go:719] "ControllerExpandVolume: skipping non-qemu VM" VM="nas"
I0522 17:52:12.731085       1 controller.go:719] "ControllerExpandVolume: skipping non-qemu VM" VM="portainer-prom"
I0522 17:52:12.731091       1 controller.go:719] "ControllerExpandVolume: skipping non-qemu VM" VM="XXXXX-public"
I0522 17:52:12.731095       1 controller.go:719] "ControllerExpandVolume: skipping non-qemu VM" VM="clickhouse0"
I0522 17:52:12.731099       1 controller.go:719] "ControllerExpandVolume: skipping non-qemu VM" VM="grafana"
I0522 17:52:12.731104       1 controller.go:719] "ControllerExpandVolume: skipping non-qemu VM" VM="influxdb"
I0522 17:52:12.731108       1 controller.go:719] "ControllerExpandVolume: skipping non-qemu VM" VM="redpanda0"
I0522 17:52:12.731113       1 controller.go:719] "ControllerExpandVolume: skipping non-qemu VM" VM=null
I0522 17:52:12.731117       1 controller.go:719] "ControllerExpandVolume: skipping non-qemu VM" VM="frigate"
I0522 17:52:12.731121       1 controller.go:719] "ControllerExpandVolume: skipping non-qemu VM" VM="streamer"
I0522 17:52:12.731126       1 controller.go:719] "ControllerExpandVolume: skipping non-qemu VM" VM="roach1"
I0522 17:52:12.731130       1 controller.go:719] "ControllerExpandVolume: skipping non-qemu VM" VM="roach2"
I0522 17:52:12.731134       1 controller.go:719] "ControllerExpandVolume: skipping non-qemu VM" VM=null
I0522 17:52:12.731139       1 controller.go:719] "ControllerExpandVolume: skipping non-qemu VM" VM="roach4"
```

## Why? (reasoning)

See https://github.com/sergelogvinov/proxmox-csi-plugin/discussions/364

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
