### PR TITLE
fix: remove the pv from the dead node

### DIFF
--- a/pkg/csi/controller_test.go
+++ b/pkg/csi/controller_test.go
@@ -814,6 +814,13 @@ func (ts *configuredTestSuite) TestDeleteVolume() {
 			expectedError: status.Error(codes.Internal, "proxmox cluster fake-region not found"),
 		},
 		{
+			msg: "WrongPVZone",
+			request: &proto.DeleteVolumeRequest{
+				VolumeId: "cluster-1/pve-removed/local-lvm/vm-9999-pvc-non-exist",
+			},
+			expected: &proto.DeleteVolumeResponse{},
+		},
+		{
 			msg: "VolumeIDNonExist",
 			request: &proto.DeleteVolumeRequest{
 				VolumeId: "cluster-1/pve-1/wrong-volume/vm-9999-pvc-non-exist",
@@ -1053,6 +1060,13 @@ func (ts *configuredTestSuite) TestControllerUnpublishVolumeError() {
 				VolumeId: "cluster-1/pve-1/local-lvm/vm-9999-pvc-123",
 			},
 			expectedError: status.Error(codes.InvalidArgument, "nodes \"cluster-1-node-3\" not found"),
+		},
+		{
+			msg: "WrongPVZone",
+			request: &proto.ControllerUnpublishVolumeRequest{
+				NodeId:   "cluster-1-node-2",
+				VolumeId: "cluster-1/pve-removed/local-lvm/vm-9999-pvc-exist",
+			},
 		},
 		{
 			msg: "AlreadyDetached",
@@ -1308,6 +1322,15 @@ func (ts *configuredTestSuite) TestControllerExpandVolumeError() {
 			msg: "WrongPVC",
 			request: &proto.ControllerExpandVolumeRequest{
 				VolumeId:         "cluster-1/pve-1/local-lvm/vm-9999-pvc-none",
+				CapacityRange:    capRange,
+				VolumeCapability: volCapability,
+			},
+			expected: &proto.ControllerExpandVolumeResponse{},
+		},
+		{
+			msg: "WrongPVZone",
+			request: &proto.ControllerExpandVolumeRequest{
+				VolumeId:         "cluster-1/pve-removed/local-lvm/vm-9999-pvc-exist",
 				CapacityRange:    capRange,
 				VolumeCapability: volCapability,
 			},


### PR DESCRIPTION
We need to check if the Proxmox node exists, and allow cleanup of all PV devices if the node is no longer present.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

part of https://github.com/sergelogvinov/proxmox-csi-plugin/issues/371

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
