### PR TITLE
feat: lifecycle management for pv

### DIFF
--- a/pkg/csi/controller_test.go
+++ b/pkg/csi/controller_test.go
@@ -377,7 +377,52 @@ func (ts *baseCSITestSuite) setupTestSuite(config string) error {
 		},
 	}
 
-	kclient := fake.NewSimpleClientset(nodes)
+	pv := &corev1.PersistentVolumeList{
+		Items: []corev1.PersistentVolume{
+			{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "PersistentVolume",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pvc-123",
+				},
+			},
+			{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "PersistentVolume",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pvc-123-lifecycle",
+					Annotations: map[string]string{
+						csi.PVAnnotationLifecycle: "keep",
+					},
+				},
+			},
+			{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "PersistentVolume",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pvc-error",
+				},
+			},
+			{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "PersistentVolume",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "pvc-non-exist",
+					Annotations: map[string]string{},
+				},
+			},
+		},
+	}
+
+	kclient := fake.NewClientset(nodes, pv)
 
 	cluster, err := proxmox.NewCluster(&cfg, &http.Client{})
 	if err != nil {

--- a/pkg/csi/driver.go
+++ b/pkg/csi/driver.go
@@ -34,6 +34,9 @@ const (
 
 	// EncryptionPassphraseKey is the encryption passphrase secret key
 	EncryptionPassphraseKey = "encryption-passphrase"
+
+	// PVAnnotationLifecycle is the annotation key for the lifecycle of a PersistentVolume
+	PVAnnotationLifecycle = DriverName + "/lifecycle"
 )
 
 // constants for fstypes

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -108,3 +108,13 @@ func (v *Volume) VMID() string {
 
 	return parts[1]
 }
+
+// PV function returns the kubernetes Persistent Volume (PV) name associated with the volume.
+func (v *Volume) PV() string {
+	parts := strings.SplitN(v.disk, "-", 3)
+	if len(parts) != 3 {
+		return ""
+	}
+
+	return parts[2]
+}


### PR DESCRIPTION
It makes it possible to delete PersistentVolumes while keeping the disk safe on the Proxmox side.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

https://github.com/sergelogvinov/proxmox-csi-plugin/issues/371

Old-style PVs can be deleted without removing the Ceph disk, allowing new PVs to be created with updated VolumeIDs.
Just add annotations to the PV

```yaml
apiVersion: v1
kind: PersistentVolume
metadata:
  annotations:
    csi.proxmox.sinextra.dev/lifecycle: "keep"
```

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
