### PR TITLE
fix: unpublish when the node no longer exists

### DIFF
--- a/pkg/csi/controller.go
+++ b/pkg/csi/controller.go
@@ -585,6 +585,12 @@ func (d *ControllerService) ControllerUnpublishVolume(ctx context.Context, reque
 
 	vmr, err := d.getVMRefbyNodeID(ctx, cl, nodeID)
 	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			klog.V(3).InfoS("ControllerUnpublishVolume: node does not exist", "volumeID", vol.VolumeID(), "nodeID", nodeID)
+
+			return &csi.ControllerUnpublishVolumeResponse{}, nil
+		}
+
 		return nil, err
 	}
 

--- a/pkg/csi/controller_test.go
+++ b/pkg/csi/controller_test.go
@@ -1104,7 +1104,6 @@ func (ts *configuredTestSuite) TestControllerUnpublishVolumeError() {
 				NodeId:   "cluster-1-node-3",
 				VolumeId: "cluster-1/pve-1/local-lvm/vm-9999-pvc-123",
 			},
-			expectedError: status.Error(codes.InvalidArgument, "nodes \"cluster-1-node-3\" not found"),
 		},
 		{
 			msg: "WrongPVZone",


### PR DESCRIPTION
When a VM is removed along with its block devices, we need to complete the unpublish process.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

https://github.com/sergelogvinov/proxmox-csi-plugin/issues/371#issuecomment-2955518203

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
