### PR TITLE
Add possibility to customize pod labels

### DIFF
--- a/charts/proxmox-csi-plugin/Chart.yaml
+++ b/charts/proxmox-csi-plugin/Chart.yaml
@@ -18,7 +18,7 @@ maintainers:
     url: https://github.com/sergelogvinov
 #
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.10
+version: 0.3.11
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/proxmox-csi-plugin/README.md
+++ b/charts/proxmox-csi-plugin/README.md
@@ -113,6 +113,7 @@ helm upgrade -i --namespace=csi-proxmox -f proxmox-csi.yaml \
 | config | object | `{"clusters":[],"features":{"provider":"default"}}` | Proxmox cluster config. ref: https://github.com/sergelogvinov/proxmox-csi-plugin/blob/main/docs/install.md |
 | storageClass | list | `[]` | Storage class definition. |
 | controller.podAnnotations | object | `{}` | Annotations for controller pod. ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
+| controller.podLabels | object | `{}` | Labels for controller pod. ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ |
 | controller.plugin.image | object | `{"pullPolicy":"IfNotPresent","repository":"ghcr.io/sergelogvinov/proxmox-csi-controller","tag":""}` | Controller CSI Driver. |
 | controller.plugin.resources | object | `{"requests":{"cpu":"10m","memory":"16Mi"}}` | Controller resource requests and limits. ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
 | controller.attacher.image | object | `{"pullPolicy":"IfNotPresent","repository":"registry.k8s.io/sig-storage/csi-attacher","tag":"v4.9.0"}` | CSI Attacher. ref: https://github.com/kubernetes-csi/external-attacher |
@@ -140,6 +141,7 @@ helm upgrade -i --namespace=csi-proxmox -f proxmox-csi.yaml \
 | initContainers | list | `[]` | Add additional init containers for the CSI controller pods. ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/ |
 | hostAliases | list | `[]` | hostAliases Deployment pod host aliases ref: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/ |
 | podAnnotations | object | `{}` | Annotations for controller pod. ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
+| podLabels | object | `{}` | Labels for controller pod. ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ |
 | podSecurityContext | object | `{"fsGroup":65532,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532}` | Controller Security Context. ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Controller Container Security Context. ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod |
 | updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | Controller deployment update strategy type. ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#updating-a-deployment |

--- a/charts/proxmox-csi-plugin/templates/controller-deployment.yaml
+++ b/charts/proxmox-csi-plugin/templates/controller-deployment.yaml
@@ -27,6 +27,9 @@ spec:
       {{- end }}
       labels:
         {{- include "proxmox-csi-plugin.selectorLabels" . | nindent 8 }}
+        {{- with default .Values.podLabels .Values.controller.podLabels -}}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/charts/proxmox-csi-plugin/templates/node-deployment.yaml
+++ b/charts/proxmox-csi-plugin/templates/node-deployment.yaml
@@ -19,6 +19,9 @@ spec:
       {{- end }}
       labels:
         {{- include "proxmox-csi-plugin-node.selectorLabels" . | nindent 8 }}
+        {{- with default .Values.podLabels -}}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       priorityClassName: system-node-critical
       {{- with .Values.imagePullSecrets }}

--- a/charts/proxmox-csi-plugin/values.yaml
+++ b/charts/proxmox-csi-plugin/values.yaml
@@ -108,6 +108,10 @@ controller:
     # prometheus.io/scrape: "true"
     # prometheus.io/port: "8080"
 
+  # -- Labels for controller pod.
+  # ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
+
   plugin:
     # -- Controller CSI Driver.
     image:
@@ -271,6 +275,10 @@ hostAliases:
 # -- Annotations for controller pod.
 # ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 podAnnotations: {}
+
+# -- Labels for controller pod.
+# ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
 
 # -- Controller Security Context.
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)
Add possibility to add additional labels to pods

## Why? (reasoning)
Any external app which selects pods, does this with pod labels, in some cases when pod labels are standardized it's better to add additional label then to use already generated for simplicity of external actor. 

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
