### PR TITLE
fix: pveum role add command missing '.Disk' in install.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -18,7 +18,7 @@ Create `CSI` role in Proxmox:
 ```shell
 pveum role add CSI -privs "VM.Audit VM.Config.Disk Datastore.Allocate Datastore.AllocateSpace Datastore.Audit"
 # Or if you need to use Replication feature
-pveum role add CSI -privs "VM.Audit VM.Config VM.Allocate Datastore.Allocate Datastore.AllocateSpace Datastore.Audit"
+pveum role add CSI -privs "VM.Audit VM.Config.Disk VM.Allocate Datastore.Allocate Datastore.AllocateSpace Datastore.Audit"
 ```
 
 Next create a user `kubernetes-csi@pve` for the CSI plugin and grant it the above role


### PR DESCRIPTION
## What? (description)

Adds missing '.Disk' in install.md

## Why? (reasoning)

The first version of the role add command uses `VM.Config.Disk` privilege while the replication version uses `VM.Config` which will fail with:

```bash
400 Parameter verification failed.
privs: invalid format - invalid privilege 'VM.Config'
```

## Acceptance

Command doesn't fail

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
