### PR TITLE
feat: add config options token_id_file & token_secret_file

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -14,7 +14,9 @@ clusters:
     insecure: false
     # Proxmox api token
     token_id: "kubernetes-csi@pve!csi"
+    token_id_file: "/etc/proxmox/token_id"          # Optional, alternative to token_id
     token_secret: "secret"
+    token_secret_file: "/etc/proxmox/token_secret"  # Optional, alternative to token_secret
     # Region name, which is cluster name
     region: Region-1
 
@@ -33,7 +35,9 @@ You can define multiple clusters in the `clusters` section.
 * `url` - The URL of the Proxmox cluster API.
 * `insecure` - Set to `true` to skip TLS certificate verification.
 * `token_id` - The Proxmox API token ID.
+* `token_id_file` - The path to a file containing the Proxmox API token ID. This is an alternative to `token_id`.
 * `token_secret` - The name of the Kubernetes Secret that contains the Proxmox API token.
+* `token_secret_file` - The path to a file containing the Proxmox API token secret. This is an alternative to `token_secret`.
 * `region` - The name of the region, which is also used as `topology.kubernetes.io/region` label.
 
 ## Feature flags


### PR DESCRIPTION
Adds additional config options to read proxmox-cluster credentials from separate files.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

https://github.com/sergelogvinov/proxmox-csi-plugin/issues/423

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for file-based token authentication in Proxmox cluster configurations
  * Introduced optional configuration fields for token ID and token secret files
* **Documentation**
  * Updated configuration documentation to explain new file-based authentication options
* **Bug Fixes**
  * Enhanced authentication validation to ensure only one credential method is used
* **Tests**
  * Added test coverage for file-based token authentication scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->