### PR TITLE
feat: support vm name with fqdn

### DIFF
--- a/pkg/csi/driver.go
+++ b/pkg/csi/driver.go
@@ -49,5 +49,14 @@ const (
 
 // constants for node labels
 const (
+	// ProxmoxCCMTopology is the base topology label from Proxmox CCM
+	ProxmoxCCMTopology = "topology.proxmox.sinextra.dev"
+
+	// ProxmoxRegion is the Proxmox region (cluster name) label
+	ProxmoxRegion = ProxmoxCCMTopology + "/region"
+	// ProxmoxNode is the Proxmox node name label
+	ProxmoxNode = ProxmoxCCMTopology + "/node"
+
+	// NodeLabelMaxVolumeAttachments is the node label for maximum volume attachments
 	NodeLabelMaxVolumeAttachments = DriverName + "/max-volume-attachments"
 )

--- a/pkg/csi/helper.go
+++ b/pkg/csi/helper.go
@@ -61,9 +61,7 @@ func locationFromTopologyRequirement(tr *proto.TopologyRequirement) (region, zon
 	for _, top := range tr.GetPreferred() {
 		segment := top.GetSegments()
 
-		tsr := segment[corev1.LabelTopologyRegion]
-		tsz := segment[corev1.LabelTopologyZone]
-
+		tsr, tsz := getNodeTopology(segment)
 		if tsr != "" && tsz != "" {
 			return tsr, tsz
 		}
@@ -76,9 +74,7 @@ func locationFromTopologyRequirement(tr *proto.TopologyRequirement) (region, zon
 	for _, top := range tr.GetRequisite() {
 		segment := top.GetSegments()
 
-		tsr := segment[corev1.LabelTopologyRegion]
-		tsz := segment[corev1.LabelTopologyZone]
-
+		tsr, tsz := getNodeTopology(segment)
 		if tsr != "" && tsz != "" {
 			return tsr, tsz
 		}
@@ -89,4 +85,18 @@ func locationFromTopologyRequirement(tr *proto.TopologyRequirement) (region, zon
 	}
 
 	return region, ""
+}
+
+func getNodeTopology(labels map[string]string) (region, zone string) {
+	region = labels[ProxmoxRegion]
+	if region == "" {
+		region = labels[corev1.LabelTopologyRegion]
+	}
+
+	zone = labels[ProxmoxNode]
+	if zone == "" {
+		zone = labels[corev1.LabelTopologyZone]
+	}
+
+	return region, zone
 }

--- a/pkg/csi/helper_test.go
+++ b/pkg/csi/helper_test.go
@@ -50,8 +50,6 @@ func TestParseEndpoint(t *testing.T) {
 	}
 
 	for _, testCase := range tests {
-		testCase := testCase
-
 		t.Run(fmt.Sprint(testCase.msg), func(t *testing.T) {
 			t.Parallel()
 
@@ -158,8 +156,6 @@ func TestLocationFromTopologyRequirement(t *testing.T) {
 	}
 
 	for _, testCase := range tests {
-		testCase := testCase
-
 		t.Run(fmt.Sprint(testCase.msg), func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/csi/node.go
+++ b/pkg/csi/node.go
@@ -544,16 +544,6 @@ func (n *NodeService) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest
 		return nil, fmt.Errorf("failed to get node %s: %w", n.nodeID, err)
 	}
 
-	region := node.Labels[corev1.LabelTopologyRegion]
-	if region == "" {
-		return nil, fmt.Errorf("failed to get region for node %s", n.nodeID)
-	}
-
-	zone := node.Labels[corev1.LabelTopologyZone]
-	if zone == "" {
-		return nil, fmt.Errorf("failed to get zone for node %s", n.nodeID)
-	}
-
 	nodeMaxVolumeAttachments, err := strconv.ParseInt(node.Labels[NodeLabelMaxVolumeAttachments], 10, 64)
 	if err != nil {
 		nodeMaxVolumeAttachments = DefaultMaxVolumesPerNode
@@ -568,6 +558,11 @@ func (n *NodeService) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest
 			DefaultMaxVolumesPerNode)
 
 		nodeMaxVolumeAttachments = DefaultMaxVolumesPerNode
+	}
+
+	region, zone := getNodeTopology(node.Labels)
+	if region == "" || zone == "" {
+		return nil, fmt.Errorf("failed to get region or zone for node %s", n.nodeID)
 	}
 
 	return &csi.NodeGetInfoResponse{

--- a/pkg/csi/node_test.go
+++ b/pkg/csi/node_test.go
@@ -513,13 +513,13 @@ func TestNodeServiceNodeGetInfo(t *testing.T) {
 			msg:           "RegionNode",
 			kclient:       fake.NewSimpleClientset(nodes),
 			nodeName:      "node-zone",
-			expectedError: fmt.Errorf("failed to get region for node node-zone"),
+			expectedError: fmt.Errorf("failed to get region or zone for node node-zone"),
 		},
 		{
 			msg:           "ZoneNode",
 			kclient:       fake.NewSimpleClientset(nodes),
 			nodeName:      "node-region",
-			expectedError: fmt.Errorf("failed to get zone for node node-region"),
+			expectedError: fmt.Errorf("failed to get region or zone for node node-region"),
 		},
 		{
 			msg:      "GoodNode",

--- a/pkg/proxmoxpool/pool_test.go
+++ b/pkg/proxmoxpool/pool_test.go
@@ -185,6 +185,12 @@ func TestFindVMByNameExist(t *testing.T) {
 					"vmid": 100,
 					"name": "test1-vm",
 				},
+				map[string]interface{}{
+					"node": "node-1",
+					"type": "qemu",
+					"vmid": 101,
+					"name": "test3-vm.domain.local",
+				},
 			},
 		}),
 	)
@@ -224,6 +230,12 @@ func TestFindVMByNameExist(t *testing.T) {
 			msg:             "Test1-VM",
 			vmName:          "test1-vm",
 			expectedVMID:    100,
+			expectedCluster: "cluster-1",
+		},
+		{
+			msg:             "Test3-VM with FQDN node name",
+			vmName:          "test3-vm",
+			expectedVMID:    101,
 			expectedCluster: "cluster-1",
 		},
 		{


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

When a VM does not have a providerID, we try to find the node using its name. In some cases, the VM name includes a domain suffix, so we need to handle that scenario as well.

## Why? (reasoning)

#413 #401

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for FQDN-based VM name lookups
  * Introduced standardized topology constants for region and zone handling

* **Bug Fixes**
  * Enhanced region and zone validation with unified error messaging
  * Improved VM identification with annotation-based fallback logic

* **Tests**
  * Updated test expectations for FQDN VM naming scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->