### PR TITLE
fix: backup volume attibute

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
         source: ./
         target: /src
   csi-attacher:
-    image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+    image: registry.k8s.io/sig-storage/csi-attacher:v4.10.0
     restart: always
     network_mode: "service:base"
     command:
@@ -43,7 +43,7 @@ services:
         source: ./hack
         target: /etc/kubernetes
   csi-resizer:
-    image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+    image: registry.k8s.io/sig-storage/csi-resizer:v2.0.0
     restart: always
     network_mode: "service:base"
     command:
@@ -61,7 +61,7 @@ services:
         source: ./hack
         target: /etc/kubernetes
   csi-provisioner:
-    image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+    image: registry.k8s.io/sig-storage/csi-provisioner:v6.0.0
     restart: always
     network_mode: "service:base"
     command:

--- a/docs/options.md
+++ b/docs/options.md
@@ -89,7 +89,7 @@ volumeBindingMode: WaitForFirstConsumer|Immediate
 You can use `VolumeAttributesClass` to redefine the mutable parameters of the `StorageClass`.
 
 ```yaml
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: VolumeAttributesClass
 metadata:
   name: proxmox-attributes

--- a/docs/volume-attributes.yaml
+++ b/docs/volume-attributes.yaml
@@ -1,18 +1,20 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: VolumeAttributesClass
 metadata:
   name: test
 driverName: csi.proxmox.sinextra.dev
 parameters:
+  backup: "true"
   diskIOPS: "400"
   diskMBps: "120"
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: VolumeAttributesClass
 metadata:
   name: test-2
 driverName: csi.proxmox.sinextra.dev
 parameters:
+  backup: "false"
   diskIOPS: "500"
   diskMBps: "200"
 ---

--- a/pkg/csi/parameters.go
+++ b/pkg/csi/parameters.go
@@ -68,7 +68,7 @@ type StorageParameters struct {
 	BlockSize *int `cfg:"blockSize"`
 	InodeSize *int `cfg:"inodeSize"`
 
-	Replicate         *bool  `json:"replicate,omitempty"      cfg:"replicate"`
+	Replicate         *bool  `json:"replicate,omitempty"   cfg:"replicate"`
 	ReplicateSchedule string `cfg:"replicateSchedule"`
 	ReplicateZones    string `cfg:"replicateZones"`
 }
@@ -121,7 +121,7 @@ func ExtractAndDefaultParameters(parameters map[string]string) (StorageParameter
 				case reflect.String:
 					f.Set(reflect.ValueOf(ptr.Ptr(v)))
 				case reflect.Bool:
-					f.Set(reflect.ValueOf(ptr.Ptr(v == "true")))
+					f.Set(reflect.ValueOf(ptr.Ptr(v == "true" || v == "1")))
 				case reflect.Int:
 					i, err := strconv.Atoi(v)
 					if err != nil {
@@ -135,7 +135,7 @@ func ExtractAndDefaultParameters(parameters map[string]string) (StorageParameter
 				case reflect.String:
 					f.Set(reflect.ValueOf(v))
 				case reflect.Bool:
-					f.Set(reflect.ValueOf(v == "true"))
+					f.Set(reflect.ValueOf(v == "true" || v == "1"))
 				case reflect.Int:
 					i, err := strconv.Atoi(v)
 					if err != nil {
@@ -209,7 +209,7 @@ func ExtractModifyVolumeParameters(parameters map[string]string) (ModifyVolumePa
 				case reflect.String:
 					f.Set(reflect.ValueOf(ptr.Ptr(v)))
 				case reflect.Bool:
-					f.Set(reflect.ValueOf(ptr.Ptr(v == "true")))
+					f.Set(reflect.ValueOf(ptr.Ptr(v == "true" || v == "1")))
 				case reflect.Int:
 					if i, err := strconv.Atoi(v); err == nil {
 						f.Set(reflect.ValueOf(ptr.Ptr(i)))
@@ -237,10 +237,8 @@ func (p StorageParameters) ToMap() map[string]string {
 	m := make(map[string]string)
 
 	val := reflect.ValueOf(p)
-	typ := reflect.TypeOf(p)
-
 	for i := 0; i < val.NumField(); i++ {
-		fieldName := typ.Field(i).Tag.Get("json")
+		fieldName := reflect.TypeOf(p).Field(i).Tag.Get("json")
 		if fieldName == "" {
 			continue
 		}

--- a/pkg/csi/parameters_test.go
+++ b/pkg/csi/parameters_test.go
@@ -82,7 +82,7 @@ func Test_ExtractAndDefaultParameters(t *testing.T) {
 				csi.StorageIDKey:       "local-lvm",
 				csi.StorageSSDKey:      "true",
 				csi.StorageDiskIOPSKey: "100",
-				"backup":               "true",
+				"backup":               "1",
 			},
 			storage: csi.StorageParameters{
 				Backup:    ptr.Ptr(true),
@@ -98,11 +98,12 @@ func Test_ExtractAndDefaultParameters(t *testing.T) {
 			msg: "replication disk",
 			params: map[string]string{
 				csi.StorageIDKey: "local-lvm",
+				"backup":         "true",
 				"replicate":      "true",
 				"replicateZones": "zone1,zone2",
 			},
 			storage: csi.StorageParameters{
-				Backup:         ptr.Ptr(false),
+				Backup:         ptr.Ptr(true),
 				IOThread:       true,
 				Replicate:      ptr.Ptr(true),
 				ReplicateZones: "zone1,zone2",


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

The Backup attribute can be defined either as a boolean value (true/false) or as an integer with a value of 1 to enable it.

## Why? (reasoning)

#342

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Container & Dependencies**
  * Updated CSI component container images to newer versions.

* **Documentation**
  * Updated manifest examples to use VolumeAttributesClass storage.k8s.io/v1 API.
  * Added backup parameter examples to VolumeAttributesClass manifests.

* **Features & Improvements**
  * Support for interpreting "1" as true in boolean parameters.
  * Backup parameter now recognized in relevant configuration parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->