### PR TITLE
refactor: storage parameters on node side

### DIFF
--- a/pkg/csi/node_test.go
+++ b/pkg/csi/node_test.go
@@ -118,7 +118,9 @@ func TestNodeStageVolumeErrors(t *testing.T) {
 				VolumeId:          "pvc-1",
 				StagingTargetPath: "/staging",
 				VolumeCapability:  volcap,
-				PublishContext:    map[string]string{},
+				PublishContext: map[string]string{
+					"lun": "1",
+				},
 			},
 			expectedError: fmt.Errorf("DevicePath must be provided"),
 		},

--- a/pkg/csi/parameters.go
+++ b/pkg/csi/parameters.go
@@ -120,7 +120,7 @@ func ExtractAndDefaultParameters(parameters map[string]string) (StorageParameter
 				case reflect.String:
 					f.Set(reflect.ValueOf(ptr.Ptr(v)))
 				case reflect.Bool:
-					f.Set(reflect.ValueOf(ptr.Ptr(v == "true" || v == "1")))
+					f.Set(reflect.ValueOf(ptr.Ptr(v == "true" || v == "1"))) //nolint:goconst
 				case reflect.Int, reflect.Int32, reflect.Int64:
 					i, err := strconv.Atoi(v)
 					if err != nil {
@@ -134,7 +134,7 @@ func ExtractAndDefaultParameters(parameters map[string]string) (StorageParameter
 				case reflect.String:
 					f.Set(reflect.ValueOf(v))
 				case reflect.Bool:
-					f.Set(reflect.ValueOf(v == "true" || v == "1"))
+					f.Set(reflect.ValueOf(v == "true" || v == "1")) //nolint:goconst
 				case reflect.Int, reflect.Int32, reflect.Int64:
 					i, err := strconv.Atoi(v)
 					if err != nil {
@@ -208,7 +208,7 @@ func ExtractModifyVolumeParameters(parameters map[string]string) (ModifyVolumePa
 				case reflect.String:
 					f.Set(reflect.ValueOf(ptr.Ptr(v)))
 				case reflect.Bool:
-					f.Set(reflect.ValueOf(ptr.Ptr(v == "true" || v == "1")))
+					f.Set(reflect.ValueOf(ptr.Ptr(v == "true" || v == "1"))) //nolint:goconst
 				case reflect.Int, reflect.Int32, reflect.Int64:
 					if i, err := strconv.Atoi(v); err == nil {
 						f.Set(reflect.ValueOf(ptr.Ptr(i)))


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

Use the StorageParameters struct on the node plugin side.

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced PublishContext validation to prevent staging failures.

* **Improvements**
  * More robust parameter handling for mount and format options, yielding more reliable mounts across filesystems.
  * Enhanced logging of mounting decisions, including device path, filesystem type, mount options and format choices.

* **Tests**
  * Updated test cases to reflect stricter PublishContext requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->