### PR TITLE
feat: full copy snapshot

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,23 @@ services:
       - type: bind
         source: ./hack
         target: /etc/kubernetes
+  csi-snapshotter:
+    image: registry.k8s.io/sig-storage/csi-snapshotter:v8.4.0
+    restart: always
+    network_mode: "service:base"
+    command:
+      - "--v=5"
+      - "--worker-threads=1"
+      - "--csi-address=unix:///csi/csi.sock"
+      - "--leader-election=false"
+      - "--kubeconfig=/etc/kubernetes/kubeconfig"
+    volumes:
+      - type: volume
+        source: socket-dir
+        target: /csi
+      - type: bind
+        source: ./hack
+        target: /etc/kubernetes
   csi-provisioner:
     image: registry.k8s.io/sig-storage/csi-provisioner:v6.0.0
     restart: always

--- a/docs/deploy/test-statefulset.yaml
+++ b/docs/deploy/test-statefulset.yaml
@@ -1,14 +1,14 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: test
+  name: test-2
   namespace: default
   labels:
     app: alpine
 spec:
   podManagementPolicy: Parallel # default is OrderedReady
   serviceName: test
-  replicas: 4
+  replicas: 1
   template:
     metadata:
       labels:
@@ -55,6 +55,6 @@ spec:
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:
-            storage: 10Gi
-        storageClassName: proxmox-lvm
+            storage: 1Gi
+        storageClassName: proxmox-zfs
         # volumeAttributesClassName: test

--- a/docs/options.md
+++ b/docs/options.md
@@ -145,7 +145,7 @@ Allow you to resize (expand) the PVC in future.
 
 ## ReclaimPolicy
 
-It defines what happens to the storage volume when the associated PersistentVolumeClaim (PVC) is deleted. There are three reclaim policies:
+It defines what happens to the storage volume when the associated PersistentVolumeClaim (PVC) is deleted. There are two reclaim policies:
 
 * `Retain`: The storage volume is not deleted when the PVC is released, and it must be manually reclaimed by an administrator.
 * `Delete`: The storage volume is deleted when the PVC is released.

--- a/docs/proxmox-zfs.yaml
+++ b/docs/proxmox-zfs.yaml
@@ -7,10 +7,13 @@ parameters:
   csi.storage.k8s.io/fstype: xfs
   #
   storage: zfs
+  ssd: "true"
+  aio: native
+  cache: directsync
   #
-  replicate: "true"
-  replicateSchedule: "*/15"
-  replicateZones: "pve-1,pve-2"
+  # replicate: "true"
+  # replicateSchedule: "*/15"
+  # replicateZones: "pve-1,pve-2"
 provisioner: csi.proxmox.sinextra.dev
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer

--- a/docs/volume-snapshot-restore.yaml
+++ b/docs/volume-snapshot-restore.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: storage-test-2-restore
+  namespace: default
+spec:
+  storageClassName: proxmox-zfs
+  dataSource:
+    apiGroup: snapshot.storage.k8s.io
+    kind: VolumeSnapshot
+    name: test
+  # dataSource:
+  #   kind: PersistentVolumeClaim
+  #   name: storage-test-2-0
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 55Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-2-restore
+  namespace: default
+spec:
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+  nodeSelector:
+    kubernetes.io/hostname: web-02a
+  containers:
+    - name: alpine
+      image: alpine
+      command: ["sleep", "6000"]
+      volumeMounts:
+        - name: pvc
+          mountPath: /mnt
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
+        runAsNonRoot: true
+  terminationGracePeriodSeconds: 1
+  securityContext:
+    fsGroup: 65534
+    runAsGroup: 65534
+    runAsUser: 65534
+  volumes:
+    - name: pvc
+      persistentVolumeClaim:
+        claimName: storage-test-2-restore

--- a/docs/volume-snapshot.yaml
+++ b/docs/volume-snapshot.yaml
@@ -1,0 +1,19 @@
+# ---
+# apiVersion: snapshot.storage.k8s.io/v1
+# kind: VolumeSnapshotClass
+# metadata:
+#   name: proxmox
+# parameters:
+#   zone: rnd-2
+# driver: csi.proxmox.sinextra.dev
+# deletionPolicy: Delete
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: test
+  namespace: default
+spec:
+  volumeSnapshotClassName: proxmox
+  source:
+    persistentVolumeClaimName: storage-test-2-0

--- a/docs/volumesnapshot.md
+++ b/docs/volumesnapshot.md
@@ -1,0 +1,126 @@
+# Volume Snapshot
+
+Proxmox VE does not support volume snapshots natively. However, the Proxmox CSI Driver provides a way to create and manage volume snapshots using Kubernetes `VolumeSnapshot` resources.
+
+`Warning`: Note this is `experimental` feature and requires root access to Proxmox API (root@pam). All parameters and features may change in future releases.
+
+The snapshot created using this method is a full copy of the original volume, not a delta snapshot. This means that the snapshot will consume the same amount of storage as the original volume.
+
+## Prerequirements
+
+Update your Proxmox CSI Driver configuration to include all clusters where you want to enable volume snapshot support.
+Make sure to use the `root@pam` account for this feature to function properly.
+
+```yaml
+clusters:
+  - url: https://cluster-api-1.exmple.com:8006/api2/json
+    username: root@pam
+    password: "your_password"
+    ...
+```
+
+## Volume Snapshot Class
+
+Create a Kubernetes `VolumeSnapshotClass` to define how snapshots are created, and set its driver to the Proxmox CSI Driver.
+
+```yaml
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: snapshot-class-name
+parameters:
+  # Optional: specify zone to copy snapshots in a specific zone
+  zone: rnd-2
+driver: csi.proxmox.sinextra.dev
+deletionPolicy: Delete
+```
+
+### Parameters:
+
+* `zone`: (Optional) Specify the zone name to create snapshots within a specific availability zone. If not specified, the snapshot will be created in the same zone as the source volume.
+
+### DeletionPolicy
+
+The deletion policy determines what happens to a volume snapshot when its associated VolumeSnapshotClass is removed.
+There are two possible policies:
+
+* `Retain`: The VolumeSnapshotContent remains after the VolumeSnapshotClass is deleted. An administrator must manually delete or reclaim it
+* `Delete`: The VolumeSnapshotContent is automatically deleted when the VolumeSnapshotClass is deleted.
+
+## Creating a Volume Snapshot
+
+To create a volume snapshot, you need to create a `VolumeSnapshot` resource that references the `VolumeSnapshotClass` you created earlier.
+
+```yaml
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: snapshot-name
+  namespace: default
+spec:
+  volumeSnapshotClassName: snapshot-class-name
+  source:
+    persistentVolumeClaimName: pvc-source-name
+```
+
+Its takes some time to create the snapshot. You can check the status of the snapshot using the following command:
+
+```bash
+kubectl -n default get volumesnapshot snapshot-name
+```
+
+Output will look like:
+
+```shell
+NAME   READYTOUSE   SOURCEPVC          SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS   SNAPSHOTCONTENT                                    CREATIONTIME   AGE
+test   false        pvc-source-name                                          proxmox         snapcontent-e56c938a-3ead-4221-bb76-aa4aaf149dc2   52s            115s
+```
+
+Once the snapshot is ready to use, the `READYTOUSE` column will change to `true`.
+
+Now you can create a new PersistentVolumeClaim from the snapshot:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: storage-test-2-restore
+  namespace: default
+spec:
+  storageClassName: proxmox-zfs
+  dataSource:
+    apiGroup: snapshot.storage.k8s.io
+    kind: VolumeSnapshot
+    name: snapshot-name
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+```
+
+Make sure the size of the new PVC is equal to or larger than the original PVC from which the snapshot was created.
+The restore process begins automatically once the PersistentVolumeClaim is attached to a Pod
+
+## Creating a PersistentVolumeClaim from an Existing PersistentVolumeClaim
+
+You can also create a new PersistentVolumeClaim by cloning an existing PersistentVolumeClaim.
+This is done by specifying the source PersistentVolumeClaim in the `dataSource` field of the new PersistentVolumeClaim.
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: storage-test-2-restore
+  namespace: default
+spec:
+  storageClassName: proxmox-zfs
+  dataSource:
+    kind: PersistentVolumeClaim
+    name: storage-test-2-0
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 55Gi
+```

--- a/pkg/csi/driver.go
+++ b/pkg/csi/driver.go
@@ -21,7 +21,7 @@ const (
 	// DriverName is the name of the CSI driver
 	DriverName = "csi.proxmox.sinextra.dev"
 	// DriverVersion is the version of the CSI driver
-	DriverVersion = "0.6.0"
+	DriverVersion = "0.7.0"
 	// DriverSpecVersion CSI spec version
 	DriverSpecVersion = "1.12.0"
 

--- a/pkg/csi/node_test.go
+++ b/pkg/csi/node_test.go
@@ -509,19 +509,19 @@ func TestNodeServiceNodeGetInfo(t *testing.T) {
 			msg:           "NodeDesntExist",
 			kclient:       fake.NewSimpleClientset(nodes),
 			nodeName:      "nonexist-node",
-			expectedError: fmt.Errorf("failed to get node nonexist-node: nodes \"%s\" not found", "nonexist-node"),
+			expectedError: fmt.Errorf("rpc error: code = Internal desc = failed to get node nonexist-node: nodes \"nonexist-node\" not found"),
 		},
 		{
 			msg:           "RegionNode",
 			kclient:       fake.NewSimpleClientset(nodes),
 			nodeName:      "node-zone",
-			expectedError: fmt.Errorf("failed to get region or zone for node node-zone"),
+			expectedError: fmt.Errorf("rpc error: code = Internal desc = failed to get region or zone for node node-zone"),
 		},
 		{
 			msg:           "ZoneNode",
 			kclient:       fake.NewSimpleClientset(nodes),
 			nodeName:      "node-region",
-			expectedError: fmt.Errorf("failed to get region or zone for node node-region"),
+			expectedError: fmt.Errorf("rpc error: code = Internal desc = failed to get region or zone for node node-region"),
 		},
 		{
 			msg:      "GoodNode",

--- a/pkg/csi/parameters.go
+++ b/pkg/csi/parameters.go
@@ -74,6 +74,9 @@ type StorageParameters struct {
 	Replicate         *bool  `json:"replicate,omitempty"   cfg:"replicate"`
 	ReplicateSchedule string `cfg:"replicateSchedule,omitempty"`
 	ReplicateZones    string `cfg:"replicateZones,omitempty"`
+
+	ResizeRequired  *bool `json:"resizeRequired,omitempty"`
+	ResizeSizeBytes int64 `json:"resizeSizeBytes,omitempty"`
 }
 
 // ModifyVolumeParameters contains parameters to modify a volume

--- a/pkg/csi/parameters_test.go
+++ b/pkg/csi/parameters_test.go
@@ -176,6 +176,18 @@ func Test_ToMap(t *testing.T) {
 				"replicate": "1",
 			},
 		},
+		{
+			msg: "resize parameters",
+			storage: csi.StorageParameters{
+				ResizeRequired:  ptr.Ptr(true),
+				ResizeSizeBytes: 1024 * 1024 * 1024,
+			},
+			params: map[string]string{
+				"iothread":        "0",
+				"resizeRequired":  "1",
+				"resizeSizeBytes": "1073741824",
+			},
+		},
 	}
 
 	for _, testCase := range tests {
@@ -275,6 +287,20 @@ func Test_MergeMap(t *testing.T) {
 				"storage":   "lvm",
 				"ssd":       "true",
 				"blockSize": "1024",
+			},
+		},
+		{
+			msg:     "Resize param",
+			storage: csi.ModifyVolumeParameters{},
+			params: map[string]string{
+				"storage":         "lvm",
+				"resizeRequired":  "true",
+				"resizeSizeBytes": "1024",
+			},
+			expected: map[string]string{
+				"storage":         "lvm",
+				"resizeRequired":  "true",
+				"resizeSizeBytes": "1024",
 			},
 		},
 	}


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

Proxmox does not support backup, restore, or disk copy operations without an associated VM. We will use experimental code to enable snapshot functionality in this case.

This capability requires root privileges. (`root@pam` account)

## Why? (reasoning)

#247 #259

[VolumeSnapshot](https://github.com/sergelogvinov/proxmox-csi-plugin/blob/snapshotter-full/docs/volumesnapshot.md) limitations

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Volume snapshot and clone support: create, delete, restore, and clone; on-demand online volume resizing when published to nodes.
  * Added a CSI snapshotter service to the deployment.

* **Documentation**
  * New snapshot guide and example manifests demonstrating snapshot/restore/clone workflows, strict security, and node placement.

* **Chores**
  * Bumped driver version to 0.7.0.
  * Updated ZFS storage class parameters and reduced example StatefulSet replicas/storage (name updated).

* **Tests**
  * Added snapshot-focused unit and table-driven tests; updated node error-path tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->