### PR TITLE
refactor: logging verbosity

### DIFF
--- a/pkg/csi/controller.go
+++ b/pkg/csi/controller.go
@@ -982,7 +982,7 @@ func (d *ControllerService) getVMIDbyNode(ctx context.Context, nodeID string) (i
 			return id, region, nil
 		}
 
-		klog.InfoS("failed to get proxmox VMID from ProviderID", "nodeID", nodeID)
+		klog.InfoS("failed to get proxmox VMID from ProviderID", "nodeID", nodeID, "providerID", node.Spec.ProviderID)
 
 		id, region, err := d.pxpool.FindVMByNode(ctx, node)
 		if err != nil {

--- a/pkg/csi/node_test.go
+++ b/pkg/csi/node_test.go
@@ -127,8 +127,6 @@ func TestNodeStageVolumeErrors(t *testing.T) {
 	}
 
 	for _, testCase := range tests {
-		testCase := testCase
-
 		t.Run(fmt.Sprint(testCase.msg), func(t *testing.T) {
 			t.Parallel()
 
@@ -165,8 +163,6 @@ func TestNodeUnstageVolumeErrors(t *testing.T) {
 	}
 
 	for _, testCase := range tests {
-		testCase := testCase
-
 		t.Run(fmt.Sprint(testCase.msg), func(t *testing.T) {
 			t.Parallel()
 
@@ -261,8 +257,6 @@ func TestNodeServiceNodePublishVolumeErrors(t *testing.T) {
 	}
 
 	for _, testCase := range tests {
-		testCase := testCase
-
 		t.Run(fmt.Sprint(testCase.msg), func(t *testing.T) {
 			t.Parallel()
 
@@ -299,8 +293,6 @@ func TestNodeUnpublishVolumeErrors(t *testing.T) {
 	}
 
 	for _, testCase := range tests {
-		testCase := testCase
-
 		t.Run(fmt.Sprint(testCase.msg), func(t *testing.T) {
 			t.Parallel()
 
@@ -340,8 +332,6 @@ func TestNodeGetVolumeStatsErrors(t *testing.T) {
 	}
 
 	for _, testCase := range tests {
-		testCase := testCase
-
 		t.Run(fmt.Sprint(testCase.msg), func(t *testing.T) {
 			t.Parallel()
 
@@ -379,8 +369,6 @@ func TestNodeServiceNodeExpandVolumeErrors(t *testing.T) {
 	}
 
 	for _, testCase := range tests {
-		testCase := testCase
-
 		t.Run(fmt.Sprint(testCase.msg), func(t *testing.T) {
 			t.Parallel()
 
@@ -586,8 +574,6 @@ func TestNodeServiceNodeGetInfo(t *testing.T) {
 	}
 
 	for _, testCase := range tests {
-		testCase := testCase
-
 		t.Run(fmt.Sprint(testCase.msg), func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

Adjust the logger levels as follows:
* 3 - Log the final result of a function.
* 4 - Log the function call parameters.
* 5 - Log internal debug information.
* 6 - Log very detailed or noisy debug output.

## Why? (reasoning)

#467

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved diagnostic logging for volume staging, expansion, and unstaging operations and for node lookup, and introduced validated handling of the maximum volumes-per-node value used in node info responses (no behavioral changes).
* **Tests**
  * Simplified CSI node tests by removing per-iteration shadowing in subtests to streamline variable handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->