### PR TITLE
feat: check topology labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,18 @@ It is very important to use disk controller `VirtIO SCSI single` with `iothread`
 
 ### Kubernetes Topology Labels
 
-Proxmox CSI Plugin uses the well-known node labels/spec to define the disk location
+Proxmox CSI Plugin uses the well-known node labels to define the disk location:
+
 * `topology.kubernetes.io/region` - the name must be the same as in cloud config region name
 * `topology.kubernetes.io/zone` - proxmox node name
+* `topology.proxmox.sinextra.dev/region` - alternative region label (optional)
+* `topology.proxmox.sinextra.dev/node` - alternative zone label (optional)
+
+Node spec:
 * `Spec.ProviderID` - providerID magic string `proxmox://$REGION/$VMID` to help define the virtual machine ID, it cannot be changed after the first update. If it not exists, the plugin will find the VM by the name or UUID.
 
-**Important**: The `topology.kubernetes.io/region` and `topology.kubernetes.io/zone` labels __must__ be set.
-Region is the Proxmox cluster name, and zone is the Proxmox node name.
-Cluster name can be human-readable and should be the same as in Cloud config.
+**Important**: The `topology.kubernetes.io/region` and `topology.kubernetes.io/zone` topology labels **must** be set.
+Region is the Proxmox cluster name in cloud config, and zone is the Proxmox node name.
 
 The labels can be set manually using `kubectl`,
 or automatically through a tool like [Proxmox CCM](https://github.com/sergelogvinov/proxmox-cloud-controller-manager).

--- a/pkg/csi/controller.go
+++ b/pkg/csi/controller.go
@@ -630,7 +630,7 @@ func (d *ControllerService) GetCapacity(ctx context.Context, request *csi.GetCap
 
 	topology := request.GetAccessibleTopology()
 	if topology != nil {
-		region, zone := getNodeTopology(topology.GetSegments())
+		region, zone := GetNodeTopology(topology.GetSegments())
 		storageID := request.GetParameters()[StorageIDKey]
 
 		if region == "" || storageID == "" {

--- a/pkg/csi/helper.go
+++ b/pkg/csi/helper.go
@@ -122,6 +122,21 @@ func ProxmoxVMIDbyNode(node *corev1.Node) (int, error) {
 	return vmID, err
 }
 
+// GetNodeTopology extracts region and zone from the provided labels map.
+func GetNodeTopology(labels map[string]string) (region, zone string) {
+	region = labels[ProxmoxRegion]
+	if region == "" {
+		region = labels[corev1.LabelTopologyRegion]
+	}
+
+	zone = labels[ProxmoxNode]
+	if zone == "" {
+		zone = labels[corev1.LabelTopologyZone]
+	}
+
+	return region, zone
+}
+
 func locationFromTopologyRequirement(tr *proto.TopologyRequirement) (region, zone string) {
 	if tr == nil {
 		return "", ""
@@ -130,7 +145,7 @@ func locationFromTopologyRequirement(tr *proto.TopologyRequirement) (region, zon
 	for _, top := range tr.GetPreferred() {
 		segment := top.GetSegments()
 
-		tsr, tsz := getNodeTopology(segment)
+		tsr, tsz := GetNodeTopology(segment)
 		if tsr != "" && tsz != "" {
 			return tsr, tsz
 		}
@@ -143,7 +158,7 @@ func locationFromTopologyRequirement(tr *proto.TopologyRequirement) (region, zon
 	for _, top := range tr.GetRequisite() {
 		segment := top.GetSegments()
 
-		tsr, tsz := getNodeTopology(segment)
+		tsr, tsz := GetNodeTopology(segment)
 		if tsr != "" && tsz != "" {
 			return tsr, tsz
 		}
@@ -154,20 +169,6 @@ func locationFromTopologyRequirement(tr *proto.TopologyRequirement) (region, zon
 	}
 
 	return region, ""
-}
-
-func getNodeTopology(labels map[string]string) (region, zone string) {
-	region = labels[ProxmoxRegion]
-	if region == "" {
-		region = labels[corev1.LabelTopologyRegion]
-	}
-
-	zone = labels[ProxmoxNode]
-	if zone == "" {
-		zone = labels[corev1.LabelTopologyZone]
-	}
-
-	return region, zone
 }
 
 func getDevicePath(deviceContext map[string]string) (string, error) {

--- a/pkg/csi/node.go
+++ b/pkg/csi/node.go
@@ -546,7 +546,7 @@ func (n *NodeService) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest
 		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to get node %s: %v", n.nodeID, err))
 	}
 
-	region, zone := getNodeTopology(node.Labels)
+	region, zone := GetNodeTopology(node.Labels)
 	if region == "" || zone == "" {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to get region or zone for node %s", n.nodeID))
 	}


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

Check topology labels before starting the process. This helps detect and notify if any prepared nodes are missing topology information.

## Why? (reasoning)

#349

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Node startup now detects region and zone from node labels and fails fast if topology is missing.
  * Node info and capacity reporting now include derived topology for more accurate placement.

* **Refactor**
  * Topology derivation logic consolidated to a single implementation for consistency.

* **Documentation**
  * README updated with new optional topology labels and clarified ProviderID and topology semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->