### PR TITLE
feat: discovery service by smbios

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/sergelogvinov/proxmox-csi-plugin/pkg/csi"
+	utilsnode "github.com/sergelogvinov/proxmox-csi-plugin/pkg/utils/node"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientkubernetes "k8s.io/client-go/kubernetes"
@@ -106,6 +107,10 @@ func main() {
 		if nodeName == "" {
 			klog.Fatalln("node-id or NODE_NAME environment must be provided")
 		}
+	}
+
+	if _, err = utilsnode.ParseNodeID(nodeName); err != nil {
+		klog.Fatalf("Failed to parse nodeID %s: %v", nodeName, err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)

--- a/docs/options.md
+++ b/docs/options.md
@@ -1,17 +1,53 @@
 # Node
 
-Individual Kubernetes Nodes can be configured using a set of labels specific to the driver.
+Individual Kubernetes Nodes can be configured by annotations and labels to provide additional information to the Proxmox CSI Driver.
+All labels and annotations are optional.
 
 ```yaml
 apiVersion: v1
 kind: Node
 metadata:
   ...
+  annotations:
+    # Proxmox Virtual Machine ID to help identify the node
+    proxmox.sinextra.dev/instance-id: "VM-ID"
+
   labels:
+    # Topology labels to override default node topology labels
+    # Note: Kubernetes scheduler uses only default topology labels - topology.kubernetes.io/region and topology.kubernetes.io/zone
+    topology.proxmox.sinextra.dev/region: cluster-1
+    topology.proxmox.sinextra.dev/zone: pve-node-1
+
     # Maximum number of volumes that can be attached to this node, default is 24
     # Note: Currently, there is a maximum limit of 30 virtio iscsi volumes *total*, including root disks, that can be attached to a single VM in QEMU/Proxmox.
-    csi.proxmox.sinextra.dev/max-volume-attachments = "24"
+    csi.proxmox.sinextra.dev/max-volume-attachments: "24"
 ...
+```
+
+## Cloud-Init SMBIOS custom fields
+
+Also you can use Cloud-Init SMBIOS custom fields to set the Proxmox VM ID during the node creation.
+
+Proxmox VM configuration example:
+
+```yaml
+smbios1: base64=1,serial=aD13ZWItMDJhO2k9MTIwMjA=,uuid=de5b02b0-828a-4d1d-b135-2b812aa7d943
+```
+
+Where `serial` field is base64 encoded string of `aD13ZWItMDJhO2k9MTIwMjA=` which decodes to `h=web-02a;i=12020`, where `i` is the VM ID.
+More information about Proxmox Cloud-Init SMBIOS fields is available in the [Cloud-Init SMBIOS documentation](https://cloudinit.readthedocs.io/en/latest/reference/datasources/nocloud.html#dmi-specific-kernel-command-line).
+
+Terraform [Proxmox provider](https://registry.terraform.io/providers/bpg/proxmox/latest/docs/resources/virtual_environment_vm) example:
+
+```hcl
+resource "proxmox_virtual_environment_vm" "k8s-nodes" {
+  node_name           = each.value.zone
+  vm_id               = each.value.id
+
+  smbios {
+    serial = "h=${each.value.zone};i=${each.value.id}"
+  }
+}
 ```
 
 # Storage Class

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ replace github.com/luthermonson/go-proxmox => github.com/sergelogvinov/go-proxmo
 
 require (
 	github.com/container-storage-interface/spec v1.12.0
+	github.com/digitalocean/go-smbios v0.0.0-20180907143718-390a4f403a8e
 	github.com/golang/protobuf v1.5.4
 	github.com/jarcoal/httpmock v1.4.1
 	github.com/kubernetes-csi/csi-lib-utils v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/digitalocean/go-smbios v0.0.0-20180907143718-390a4f403a8e h1:vUmf0yezR0y7jJ5pceLHthLaYf4bA5T14B6q39S4q2Q=
+github.com/digitalocean/go-smbios v0.0.0-20180907143718-390a4f403a8e/go.mod h1:YTIHhz/QFSYnu/EhlF2SpU2Uk+32abacUYA5ZPljz1A=
 github.com/diskfs/go-diskfs v1.7.0 h1:vonWmt5CMowXwUc79jWyGrf2DIMeoOjkLlMnQYGVOs8=
 github.com/diskfs/go-diskfs v1.7.0/go.mod h1:LhQyXqOugWFRahYUSw47NyZJPezFzB9UELwhpszLP/k=
 github.com/djherbis/times v1.6.0 h1:w2ctJ92J8fBvWPxugmXIv7Nz7Q3iDMKNx9v5ocVH20c=
@@ -146,8 +148,6 @@ github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05Zp
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sergelogvinov/go-proxmox v0.0.0-20251106051435-dc287d182403 h1:CoK3RHVjqDhk74sfLtdHePYyjCnBBsinHnvGGqVacR4=
-github.com/sergelogvinov/go-proxmox v0.0.0-20251106051435-dc287d182403/go.mod h1:vSTg/WC771SByc5087tu7uyGaXUv6fS8q3ak2X+xwqk=
 github.com/sergelogvinov/go-proxmox v0.0.0-20251110010552-654365b267da h1:uK/GNZyaU+b1o4Ax8TJ/c99dNtT1S5pM2nj91mj1S6Q=
 github.com/sergelogvinov/go-proxmox v0.0.0-20251110010552-654365b267da/go.mod h1:vSTg/WC771SByc5087tu7uyGaXUv6fS8q3ak2X+xwqk=
 github.com/sergelogvinov/go-proxmox-luthermonson v0.0.0-20251108105505-bebdd99daf36 h1:lZWsJ35SUWSFJqsM4XzbiHQVAOZjS2uSrxfr/p2tY0o=

--- a/pkg/csi/controller_test.go
+++ b/pkg/csi/controller_test.go
@@ -641,7 +641,7 @@ func (ts *configuredTestSuite) TestControllerPublishVolumeError() {
 				VolumeCapability: volCap,
 				VolumeContext:    volCtx,
 			},
-			expectedError: status.Error(codes.InvalidArgument, "NodeID must be provided"),
+			expectedError: status.Error(codes.InvalidArgument, "NodeID must be in format <nodeName>/<vmID> or <nodeName>"),
 		},
 		{
 			msg: "VolumeCapability",
@@ -739,7 +739,7 @@ func (ts *configuredTestSuite) TestControllerUnpublishVolumeError() {
 			request: &proto.ControllerUnpublishVolumeRequest{
 				VolumeId: "volume-id",
 			},
-			expectedError: status.Error(codes.InvalidArgument, "NodeID must be provided"),
+			expectedError: status.Error(codes.InvalidArgument, "NodeID must be in format <nodeName>/<vmID> or <nodeName>"),
 		},
 		{
 			msg: "WrongVolumeID",

--- a/pkg/tools/kubernetes/nodes.go
+++ b/pkg/tools/kubernetes/nodes.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	utilsnode "github.com/sergelogvinov/proxmox-csi-plugin/pkg/utils/node"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clientkubernetes "k8s.io/client-go/kubernetes"
@@ -37,7 +39,12 @@ func CSINodes(ctx context.Context, kclient *clientkubernetes.Clientset, csiDrive
 	for _, csinode := range csinodes.Items {
 		for _, driver := range csinode.Spec.Drivers {
 			if driver.Name == csiDriverName {
-				nodes = append(nodes, driver.NodeID)
+				n, err := utilsnode.ParseNodeID(driver.NodeID)
+				if err != nil {
+					continue
+				}
+
+				nodes = append(nodes, n.GetNodeName())
 
 				break
 			}

--- a/pkg/utils/node/doc.go
+++ b/pkg/utils/node/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package node implements the utilities to work with Proxmox VM ID and CSI NodeID.
+package node

--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ID is the node ID magic string for CSI Node ID.
+type ID struct {
+	id   int
+	node string
+}
+
+// ParseNodeID returns the ID struct from the magic nodeID string.
+func ParseNodeID(nodeID string) (n ID, err error) {
+	errMsg := fmt.Errorf("NodeID must be in format <nodeName>/<vmID> or <nodeName>")
+
+	if nodeID == "" {
+		return ID{}, errMsg
+	}
+
+	vmID := 0
+
+	parts := strings.SplitN(nodeID, "/", 2)
+	if parts[0] == "" {
+		return ID{}, errMsg
+	}
+
+	if len(parts) == 2 {
+		vmID, err = strconv.Atoi(parts[1])
+		if err != nil {
+			return ID{}, errMsg
+		}
+
+		return ID{id: vmID, node: parts[0]}, nil
+	}
+
+	return ID{id: vmID, node: parts[0]}, nil
+}
+
+// GetNodeID returns the CSI NodeID magic string.
+func GetNodeID(nodeName string) (n ID, err error) {
+	info, err := GetSMBIOSInfo()
+	if err != nil {
+		return ParseNodeID(nodeName)
+	}
+
+	vmID := 0
+
+	if info.SerialNumber != "" {
+		options := strings.Split(info.SerialNumber, ";")
+		for _, option := range options {
+			parts := strings.SplitN(option, "=", 2)
+			if len(parts) == 2 {
+				if parts[0] == "i" {
+					vmID, err = strconv.Atoi(parts[1])
+					if err != nil {
+						return ParseNodeID(nodeName)
+					}
+				}
+			}
+		}
+	}
+
+	return ID{id: vmID, node: nodeName}, nil
+}
+
+// GetNodeName returns the node name from the nodeID.
+func (n ID) GetNodeName() string {
+	return n.node
+}
+
+// GetVMID returns the VM ID from the nodeID.
+func (n ID) GetVMID() (int, error) {
+	if n.id != 0 {
+		return n.id, nil
+	}
+
+	return 0, fmt.Errorf("NodeID does not have VM ID")
+}
+
+func (n ID) String() string {
+	if n.id != 0 {
+		return fmt.Sprintf("%s/%d", n.node, n.id)
+	}
+
+	return n.node
+}

--- a/pkg/utils/node/node_test.go
+++ b/pkg/utils/node/node_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sergelogvinov/proxmox-csi-plugin/pkg/utils/node"
+)
+
+func TestNodeID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		msg       string
+		nodeID    string
+		VMName    string
+		VMNameErr error
+		VMID      int
+		VMIDErr   error
+	}{
+		{
+			msg:     "Test Node ID",
+			nodeID:  "node-123",
+			VMName:  "node-123",
+			VMID:    0,
+			VMIDErr: fmt.Errorf("NodeID does not have VM ID"),
+		},
+		{
+			msg:     "Test Node ID with VM ID",
+			nodeID:  "node-123/456",
+			VMName:  "node-123",
+			VMID:    456,
+			VMIDErr: nil,
+		},
+		{
+			msg:       "Test Node ID with invalid VM ID",
+			nodeID:    "node-123/abc",
+			VMName:    "",
+			VMNameErr: fmt.Errorf("NodeID must be in format <nodeName>/<vmID> or <nodeName>"),
+			VMID:      0,
+			VMIDErr:   fmt.Errorf("NodeID does not have VM ID"),
+		},
+		{
+			msg:       "Test Node ID without node name",
+			nodeID:    "/456",
+			VMName:    "",
+			VMNameErr: fmt.Errorf("NodeID must be in format <nodeName>/<vmID> or <nodeName>"),
+			VMID:      0,
+			VMIDErr:   fmt.Errorf("NodeID does not have VM ID"),
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.msg, func(t *testing.T) {
+			t.Parallel()
+
+			n, err := node.ParseNodeID(testCase.nodeID)
+			id, errID := n.GetVMID()
+
+			if testCase.VMNameErr != nil {
+				assert.EqualError(t, err, testCase.VMNameErr.Error())
+			} else {
+				assert.Nil(t, err)
+			}
+
+			assert.Equal(t, testCase.VMName, n.GetNodeName())
+
+			if testCase.VMIDErr != nil {
+				assert.EqualError(t, errID, testCase.VMIDErr.Error())
+			} else {
+				assert.Nil(t, errID)
+			}
+
+			assert.Equal(t, testCase.VMID, id)
+		})
+	}
+}

--- a/pkg/utils/node/smbios.go
+++ b/pkg/utils/node/smbios.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/digitalocean/go-smbios/smbios"
+)
+
+// SystemInformation holds SMBIOS system information.
+type SystemInformation struct {
+	// Manufacturer returns the system manufacturer.
+	Manufacturer string
+	// ProductName returns the system product name.
+	ProductName string
+	// Version returns the system version.
+	Version string
+	// SerialNumber returns the system serial number.
+	SerialNumber string
+	// SKUNumber returns the system SKU number.
+	SKUNumber string
+	// Family returns the system family.
+	Family string
+}
+
+// GetSMBIOSInfo retrieves the SMBIOS system information.
+func GetSMBIOSInfo() (SystemInformation, error) {
+	rc, _, err := smbios.Stream()
+	if err != nil {
+		return SystemInformation{}, fmt.Errorf("failed to access smbios: %v", err)
+	}
+	defer rc.Close() //nolint: errcheck
+
+	d := smbios.NewDecoder(rc)
+
+	structures, err := d.Decode()
+	if err != nil {
+		return SystemInformation{}, fmt.Errorf("failed to decode smbios: %v", err)
+	}
+
+	for _, structure := range structures {
+		if structure.Header.Type == 1 {
+			return SystemInformation{
+				Manufacturer: getStringOrEmpty(structure, 0x04),
+				ProductName:  getStringOrEmpty(structure, 0x05),
+				Version:      getStringOrEmpty(structure, 0x06),
+				SerialNumber: getStringOrEmpty(structure, 0x07),
+				SKUNumber:    getStringOrEmpty(structure, 0x19),
+				Family:       getStringOrEmpty(structure, 0x1A),
+			}, nil
+		}
+	}
+
+	return SystemInformation{}, nil
+}
+
+func getStringOrEmpty(s *smbios.Structure, offset int) string {
+	index := getByte(s, offset)
+
+	if index == 0 || int(index) > len(s.Strings) {
+		return ""
+	}
+
+	trimmed := strings.ToLower(strings.TrimSpace(s.Strings[index-1]))
+	if slices.Contains([]string{
+		"to be filled by o.e.m.",
+		"default string",
+		"system product name",
+		"system serial number",
+		"not specified",
+	}, trimmed) {
+		return ""
+	}
+
+	return trimmed
+}
+
+func getByte(s *smbios.Structure, offset int) uint8 {
+	// the `Formatted` byte slice is missing the first 4 bytes of the structure that are stripped out as header info.
+	index := offset - 4
+	if index >= len(s.Formatted) {
+		return 0
+	}
+
+	return s.Formatted[index]
+}


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

CloudInit uses SMBIOS parameters that allow storing metadata such as the hostname and instance-id. We will use the instance-id value to generate the CSI NodeID.

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SMBIOS-based fallback to better determine node identity and canonicalize node IDs.
  * Utilities to parse and format node IDs supporting "<nodeName>" or "<nodeName>/<vmID>".

* **Bug Fixes**
  * Stronger node ID validation with clearer error messages and more robust behavior across publish/unpublish/info flows.

* **Tests**
  * New unit tests for node ID parsing and VM ID extraction; updated error expectations.

* **Documentation**
  * Added examples and guidance for using SMBIOS and node annotations in configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->