### PR TITLE
fix: wait for volume to attach

### DIFF
--- a/.github/workflows/charts.yaml
+++ b/.github/workflows/charts.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "charts/**"
+      - "!charts/proxmox-csi-plugin/README.md.gotmpl"
 
 jobs:
   helm-lint:

--- a/charts/proxmox-csi-plugin/README.md.gotmpl
+++ b/charts/proxmox-csi-plugin/README.md.gotmpl
@@ -29,9 +29,9 @@ Supported storage types:
 
 ```shell
 # Create role CSI
-pveum role add CSI -privs "VM.Audit VM.Config.Disk Datastore.Allocate Datastore.AllocateSpace Datastore.Audit"
+pveum role add CSI -privs "Sys.Audit VM.Audit VM.Config.Disk Datastore.Allocate Datastore.AllocateSpace Datastore.Audit"
 # Or if you need to use Replication feature (zfs replication)
-pveum role add CSI -privs "VM.Audit VM.Allocate VM.Clone VM.Config.CPU VM.Config.Disk VM.Config.HWType VM.Config.Memory VM.Config.Options VM.Migrate VM.PowerMgmt Datastore.Allocate Datastore.AllocateSpace Datastore.Audit"
+pveum role add CSI -privs "Sys.Audit VM.Audit VM.Allocate VM.Clone VM.Config.CPU VM.Config.Disk VM.Config.HWType VM.Config.Memory VM.Config.Options VM.Migrate VM.PowerMgmt Datastore.Allocate Datastore.AllocateSpace Datastore.Audit"
 
 # Create user and grant permissions
 pveum user add kubernetes-csi@pve

--- a/docs/install.md
+++ b/docs/install.md
@@ -16,9 +16,9 @@ Proxmox CSI Plugin requires the correct privileges in order to allocate and atta
 Create `CSI` role in Proxmox:
 
 ```shell
-pveum role add CSI -privs "VM.Audit VM.Config.Disk Datastore.Allocate Datastore.AllocateSpace Datastore.Audit"
+pveum role add CSI -privs "Sys.Audit VM.Audit VM.Config.Disk Datastore.Allocate Datastore.AllocateSpace Datastore.Audit"
 # Or if you need to use Replication feature (zfs replication)
-pveum role add CSI -privs "VM.Audit VM.Allocate VM.Clone VM.Config.CPU VM.Config.Disk VM.Config.HWType VM.Config.Memory VM.Config.Options VM.Migrate VM.PowerMgmt Datastore.Allocate Datastore.AllocateSpace Datastore.Audit"
+pveum role add CSI -privs "Sys.Audit VM.Audit VM.Allocate VM.Clone VM.Config.CPU VM.Config.Disk VM.Config.HWType VM.Config.Memory VM.Config.Options VM.Migrate VM.PowerMgmt Datastore.Allocate Datastore.AllocateSpace Datastore.Audit"
 ```
 
 Next create a user `kubernetes-csi@pve` for the CSI plugin and grant it the above role

--- a/pkg/csi/controller.go
+++ b/pkg/csi/controller.go
@@ -421,7 +421,7 @@ func (d *ControllerService) DeleteVolume(ctx context.Context, request *csi.Delet
 	_, err = d.checkVolume(ctx, vol)
 	if err != nil {
 		if status.Code(err) == codes.NotFound {
-			klog.ErrorS(err, "DeleteVolume: zone or volume not found", "volumeID", vol.VolumeID())
+			klog.V(3).InfoS("DeleteVolume: zone or volume not found", "volumeID", vol.VolumeID())
 
 			return &csi.DeleteVolumeResponse{}, nil
 		}
@@ -586,7 +586,7 @@ func (d *ControllerService) ControllerUnpublishVolume(ctx context.Context, reque
 	_, err = d.checkVolume(ctx, vol)
 	if err != nil {
 		if status.Code(err) == codes.NotFound {
-			klog.ErrorS(err, "ControllerUnpublishVolume: zone or volume not found", "cluster", vol.Cluster(), "volumeID", vol.VolumeID())
+			klog.V(3).InfoS("ControllerUnpublishVolume: zone or volume not found", "volumeID", vol.VolumeID())
 
 			return &csi.ControllerUnpublishVolumeResponse{}, nil
 		}
@@ -829,7 +829,7 @@ func (d *ControllerService) DeleteSnapshot(ctx context.Context, request *csi.Del
 	_, err = d.checkVolume(ctx, vol)
 	if err != nil {
 		if status.Code(err) == codes.NotFound {
-			klog.ErrorS(err, "DeleteSnapshot: zone or volume not found", "cluster", vol.Cluster(), "volumeID", vol.VolumeID())
+			klog.V(3).InfoS("DeleteSnapshot: zone or volume not found", "volumeID", vol.VolumeID())
 
 			return &csi.DeleteSnapshotResponse{}, nil
 		}


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

We need to wait until the block device appears on the virtual machine.

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Sys.Audit to Proxmox CSI role privilege lists in deployment docs and README.

* **Improvements**
  * Added polling to ensure volumes are fully attached before continuing.
  * Reduced logging severity when volumes/snapshots are not found to reduce noisy error reports.

* **Chores**
  * CI workflow adjusted to ignore changes to the plugin README file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->