### PR TITLE
feat: add Prometheus metrics support for node daemonset

### DIFF
--- a/charts/proxmox-csi-plugin/README.md
+++ b/charts/proxmox-csi-plugin/README.md
@@ -81,6 +81,12 @@ storageClass:
     reclaimPolicy: Delete
     fstype: ext4
     cache: writethrough
+
+# Enable Prometheus metrics for node daemonset using PodMonitor
+nodeMetrics:
+  enabled: true
+  type: podmonitor
+  port: 8080
 ```
 
 ## Deploy
@@ -155,6 +161,10 @@ helm upgrade -i --namespace=csi-proxmox -f proxmox-csi.yaml \
 | metrics | object | `{"enabled":false,"port":8080,"type":"annotation"}` | Prometheus metrics |
 | metrics.enabled | bool | `false` | Enable Prometheus metrics. |
 | metrics.port | int | `8080` | Prometheus metrics port. |
+| nodeMetrics | object | `{"enabled":false,"port":8080,"type":"podmonitor"}` | Prometheus metrics for node daemonset |
+| nodeMetrics.enabled | bool | `false` | Enable Prometheus metrics for node daemonset. |
+| nodeMetrics.port | int | `8080` | Prometheus metrics port for node daemonset. |
+| nodeMetrics.type | string | `"podmonitor"` | Metrics type for node daemonset. Currently only supports "podmonitor" for Prometheus Operator PodMonitor. |
 | nodeSelector | object | `{}` | Node labels for controller assignment. ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | tolerations | list | `[]` | Tolerations for controller assignment. ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
 | affinity | object | `{}` | Affinity for controller assignment. ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |

--- a/charts/proxmox-csi-plugin/templates/node-deployment.yaml
+++ b/charts/proxmox-csi-plugin/templates/node-deployment.yaml
@@ -52,6 +52,15 @@ spec:
             - "-v={{ .Values.logVerbosityLevel }}"
             - "--csi-address=unix:///csi/csi.sock"
             - "--node-id=$(NODE_NAME)"
+            {{- if .Values.nodeMetrics.enabled }}
+            - "--metrics-address=:{{ .Values.nodeMetrics.port }}"
+            {{- end }}
+          ports:
+            {{- if .Values.nodeMetrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.nodeMetrics.port }}
+              protocol: TCP
+            {{- end }}
           env:
             - name: NODE_NAME
               valueFrom:

--- a/charts/proxmox-csi-plugin/templates/node-podmonitor.yaml
+++ b/charts/proxmox-csi-plugin/templates/node-podmonitor.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.nodeMetrics.enabled (eq .Values.nodeMetrics.type "podmonitor") }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "proxmox-csi-plugin.fullname" . }}-node
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "proxmox-csi-plugin.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "proxmox-csi-plugin-node.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+{{- end }}
+

--- a/charts/proxmox-csi-plugin/values.yaml
+++ b/charts/proxmox-csi-plugin/values.yaml
@@ -329,6 +329,15 @@ metrics:
 
   type: annotation
 
+# -- Prometheus metrics for node daemonset
+nodeMetrics:
+  # -- Enable Prometheus metrics for node daemonset.
+  enabled: false
+  # -- Prometheus metrics port for node daemonset.
+  port: 8080
+  # -- Metrics type for node daemonset (podmonitor).
+  type: podmonitor
+
 # -- Node labels for controller assignment.
 # ref: https://kubernetes.io/docs/user-guide/node-selection/
 nodeSelector: {}

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"flag"
 	"net"
+	"net/http"
 	"os"
 	"time"
 
@@ -34,6 +35,7 @@ import (
 	clientkubernetes "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
 )
 
@@ -44,6 +46,9 @@ var (
 	showVersion = flag.Bool("version", false, "Print the version and exit.")
 	csiEndpoint = flag.String("csi-address", "unix:///csi/csi.sock", "CSI Endpoint")
 	nodeID      = flag.String("node-id", "", "Node name")
+
+	metricsAddress = flag.String("metrics-address", "", "The TCP network address where the HTTP server for metrics, will listen (example: `:8080`). By default the server is disabled.")
+	metricsPath    = flag.String("metrics-path", "/metrics", "The HTTP path where prometheus metrics will be exposed.")
 
 	master     = flag.String("master", "", "Master URL to build a client config from. Either this or kubeconfig needs to be set if the provisioner is being run out of cluster.")
 	kubeconfig = flag.String("kubeconfig", "", "Absolute path to the kubeconfig file. Either this or master needs to be set if the provisioner is being run out of cluster.")
@@ -149,6 +154,21 @@ func main() {
 
 	opts := []grpc.ServerOption{
 		grpc.UnaryInterceptor(logErr),
+	}
+
+	// Prepare http endpoint for metrics
+	mux := http.NewServeMux()
+	if *metricsAddress != "" {
+		mux.Handle("/metrics", legacyregistry.Handler())
+
+		go func() {
+			klog.V(2).InfoS("Metrics listening", "address", *metricsAddress, "metricsPath", *metricsPath)
+
+			err := http.ListenAndServe(*metricsAddress, mux)
+			if err != nil {
+				klog.ErrorS(err, "Failed to start HTTP server at specified address and metrics path", "address", addr, "metricsPath", *metricsPath)
+			}
+		}()
 	}
 
 	srv := grpc.NewServer(opts...)


### PR DESCRIPTION
This update introduces the ability to enable Prometheus metrics for the node daemonset. The configuration options include enabling metrics, specifying the metrics port, and defining the metrics type as "podmonitor". Additionally, the node deployment template has been updated to expose the metrics endpoint when enabled.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
