### PR TITLE
fix: migrate default timeout

### DIFF
--- a/cmd/pvecsictl/migrate.go
+++ b/cmd/pvecsictl/migrate.go
@@ -67,7 +67,7 @@ func setMigrateCmdFlags(cmd *cobra.Command) {
 	flags.StringP("namespace", "n", "", "namespace of the persistentvolumeclaims")
 
 	flags.BoolP("force", "f", false, "force migration even if the persistentvolumeclaims is in use")
-	flags.Int("timeout", 7200, "task timeout in seconds")
+	flags.Int("timeout", 10800, "task timeout in seconds")
 }
 
 // nolint: cyclop, gocyclo

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module github.com/sergelogvinov/proxmox-csi-plugin
 go 1.25.3
 
 // replace github.com/sergelogvinov/go-proxmox => ../proxmox/go-proxmox
+// replace github.com/luthermonson/go-proxmox => ../proxmox/go-proxmox-luthermonson
 
-replace github.com/luthermonson/go-proxmox => github.com/sergelogvinov/go-proxmox-luthermonson v0.0.0-20251108105505-bebdd99daf36
+replace github.com/luthermonson/go-proxmox => github.com/sergelogvinov/go-proxmox-luthermonson v0.0.0-20251120040418-5221e184a018
 
 require (
 	github.com/container-storage-interface/spec v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWN
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergelogvinov/go-proxmox v0.0.0-20251110010552-654365b267da h1:uK/GNZyaU+b1o4Ax8TJ/c99dNtT1S5pM2nj91mj1S6Q=
 github.com/sergelogvinov/go-proxmox v0.0.0-20251110010552-654365b267da/go.mod h1:vSTg/WC771SByc5087tu7uyGaXUv6fS8q3ak2X+xwqk=
-github.com/sergelogvinov/go-proxmox-luthermonson v0.0.0-20251108105505-bebdd99daf36 h1:lZWsJ35SUWSFJqsM4XzbiHQVAOZjS2uSrxfr/p2tY0o=
-github.com/sergelogvinov/go-proxmox-luthermonson v0.0.0-20251108105505-bebdd99daf36/go.mod h1:oyFgg2WwTEIF0rP6ppjiixOHa5ebK1p8OaRiFhvICBQ=
+github.com/sergelogvinov/go-proxmox-luthermonson v0.0.0-20251120040418-5221e184a018 h1:ya2kTpNTlYjBpkz7sFKQDLr0c9SfphNbWuZ9qmNserc=
+github.com/sergelogvinov/go-proxmox-luthermonson v0.0.0-20251120040418-5221e184a018/go.mod h1:oyFgg2WwTEIF0rP6ppjiixOHa5ebK1p8OaRiFhvICBQ=
 github.com/siderolabs/go-blockdevice v0.4.8 h1:KfdWvIx0Jft5YVuCsFIJFwjWEF1oqtzkgX9PeU9cX4c=
 github.com/siderolabs/go-blockdevice v0.4.8/go.mod h1:4PeOuk71pReJj1JQEXDE7kIIQJPVe8a+HZQa+qjxSEA=
 github.com/siderolabs/go-cmd v0.1.3 h1:JrgZwqhJQeoec3QRON0LK+fv+0y7d0DyY7zsfkO6ciw=

--- a/pkg/tools/proxmox/volume.go
+++ b/pkg/tools/proxmox/volume.go
@@ -82,7 +82,7 @@ func MoveQemuDisk(ctx context.Context, cluster *goproxmox.APIClient, vol *volume
 
 	task := proxmox.NewTask(upid, cluster.Client)
 	if task != nil {
-		_, completed, err := task.WaitForCompleteStatus(ctx, taskTimeout/60, 60)
+		_, completed, err := task.WaitForCompleteStatus(ctx, taskTimeout/15, 15)
 		if err != nil {
 			return fmt.Errorf("unable to delete virtual machine disk: %w", err)
 		}


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

Increase the default timeout to 3 hours.

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  - Extended default timeout for migrate operations from 7200 to 10800 seconds, providing additional time for large migrations to complete successfully
  - Optimized polling behavior for disk move operations to enhance responsiveness and completion detection

* **Chores**
  - Updated project dependencies to latest versions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->