### PR TITLE
Added new Adopter: PKE (Proxmox Kubernetes Engine)

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -7,6 +7,9 @@ This is a list of organizations or projects that have adopted the Proxmox CSI dr
 * **[Boriss Novickovs](https://github.com/kubebn/talos-proxmox-kaas)**
   Kubernetes As a Service in Proxmox. Homelab using Talos and Proxmox, including base add-ons and GitOps practices. Proxmox CCM/CSI to manage VMs and storages.
 
+* **[Proxmox Kubernetes Engine](https://github.com/Caprox-eu/Proxmox-Kubernetes-Engine)**
+  PKE (Proxmox Kubernetes Engine) is a solution for automatically deploying and managing high available Kubernetes clusters directly on Proxmox VE environments. Based on Kubernetes Cluster-API and fully API-Driven.
+
 * **[Serge Logvinov](https://github.com/sergelogvinov/terraform-talos/tree/main/proxmox)**
    Terraform example for Talos on Proxmox. I am using the Proxmox CSI plugin for GitHub Actions (for ephemeral storage) and databases on Proxmox. _Not so well documented_.
 


### PR DESCRIPTION
Added the Proxmox Kubernetes engine and added a note to [talos-proxmox-kaas](https://github.com/kubebn/talos-proxmox-kaas). It seems like its not under active maintenance. PKE can be an alternative.   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated community adopters list: added a new entry for "Proxmox Kubernetes Engine" with a descriptive paragraph, inserted into the adopters sequence between the entries for Boriss Novickovs and Serge Logvinov. No other adopter entries were modified or removed; existing entries (including Vegard Hagen) remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->