### PR TITLE
feat(chart): support affinity for node-plugin assignment.

### DIFF
--- a/charts/proxmox-csi-plugin/Chart.yaml
+++ b/charts/proxmox-csi-plugin/Chart.yaml
@@ -18,7 +18,7 @@ maintainers:
     url: https://github.com/sergelogvinov
 #
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/proxmox-csi-plugin/templates/node-deployment.yaml
+++ b/charts/proxmox-csi-plugin/templates/node-deployment.yaml
@@ -136,3 +136,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.node.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/proxmox-csi-plugin/values.yaml
+++ b/charts/proxmox-csi-plugin/values.yaml
@@ -234,6 +234,10 @@ node:
       operator: Exists
       effect: NoSchedule
 
+  # -- Affinity for node-plugin assignment.
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+
 livenessprobe:
   # -- Common livenessprobe sidecar.
   image:


### PR DESCRIPTION
**Pull Request**

**What?**
- Added `affinity` to the `node-deployment.yaml` template to support node affinity for pod assignment.
- Included `affinity` in `values.yaml` to allow configuration via Helm values.

**Why?**
- **`affinity`:** Enables precise control over pod placement on nodes based on node labels or other affinity/anti-affinity rules. This improves workload distribution, reliability, and resource utilization in the cluster.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring node affinity scheduling constraints to control pod placement.

* **Chores**
  * Version bump to 0.5.1.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->