### PR TITLE
feat(chart): add extraArgs support for CSI sidecars

### DIFF
--- a/charts/proxmox-csi-plugin/templates/controller-deployment.yaml
+++ b/charts/proxmox-csi-plugin/templates/controller-deployment.yaml
@@ -86,6 +86,9 @@ spec:
             {{- range .Values.controller.attacher.args }}
             - {{ . | quote }}
             {{- end }}
+            {{- range .Values.controller.attacher.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -105,6 +108,9 @@ spec:
             - "--capacity-ownerref-level=2"
             {{- end }}
             {{- range .Values.controller.provisioner.args }}
+            - {{ . | quote }}
+            {{- end }}
+            {{- range .Values.controller.provisioner.extraArgs }}
             - {{ . | quote }}
             {{- end }}
           env:
@@ -134,6 +140,9 @@ spec:
             {{- range .Values.controller.resizer.args }}
             - {{ . | quote }}
             {{- end }}
+            {{- range .Values.controller.resizer.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -152,6 +161,9 @@ spec:
             {{- range .Values.controller.snapshotter.args }}
             - {{ . | quote }}
             {{- end }}
+            {{- range .Values.controller.snapshotter.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -165,6 +177,9 @@ spec:
           args:
             - "-v={{ .Values.logVerbosityLevel }}"
             - "--csi-address=unix:///csi/csi.sock"
+            {{- range .Values.livenessprobe.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/charts/proxmox-csi-plugin/templates/node-deployment.yaml
+++ b/charts/proxmox-csi-plugin/templates/node-deployment.yaml
@@ -83,6 +83,9 @@ spec:
             - "-v={{ .Values.logVerbosityLevel }}"
             - "--csi-address=unix:///csi/csi.sock"
             - "--kubelet-registration-path={{ .Values.node.kubeletDir }}/plugins/{{ .Values.provisionerName }}/csi.sock"
+            {{- range .Values.node.driverRegistrar.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
           volumeMounts:
             - name: socket
               mountPath: /csi
@@ -103,6 +106,9 @@ spec:
           args:
             - "-v={{ .Values.logVerbosityLevel }}"
             - "--csi-address=unix:///csi/csi.sock"
+            {{- range .Values.livenessprobe.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
           volumeMounts:
             - name: socket
               mountPath: /csi

--- a/charts/proxmox-csi-plugin/values.yaml
+++ b/charts/proxmox-csi-plugin/values.yaml
@@ -134,6 +134,13 @@ controller:
     # example: --default-fstype=ext4
     args:
       - --default-fstype=ext4
+    # -- Extra arguments for tuning csi-attacher performance.
+    # Useful for high-load environments with many PVCs.
+    # ref: https://github.com/kubernetes-csi/external-attacher?tab=readme-ov-file#command-line-options
+    extraArgs: []
+      # - --worker-threads=10
+      # - --retry-interval-start=1s
+      # - --retry-interval-max=5m
     # -- Attacher resource requests and limits.
     # ref: https://kubernetes.io/docs/user-guide/compute-resources/
     resources:
@@ -151,6 +158,15 @@ controller:
     # example: --feature-gates=VolumeAttributesClass=true
     args:
       - --default-fstype=ext4
+    # -- Extra arguments for tuning csi-provisioner performance.
+    # Useful for high-load environments with many PVCs.
+    # ref: https://github.com/kubernetes-csi/external-provisioner?tab=readme-ov-file#command-line-options
+    extraArgs: []
+      # - --worker-threads=100
+      # - --retry-interval-start=1s
+      # - --retry-interval-max=5m
+      # - --kube-api-qps=20
+      # - --kube-api-burst=40
     # -- Provisioner resource requests and limits.
     # ref: https://kubernetes.io/docs/user-guide/compute-resources/
     resources:
@@ -167,6 +183,15 @@ controller:
     # -- Resizer arguments.
     # example: --feature-gates=VolumeAttributesClass=true
     args: []
+    # -- Extra arguments for tuning csi-resizer performance.
+    # Useful for high-load environments with many PVCs.
+    # ref: https://github.com/kubernetes-csi/external-resizer?tab=readme-ov-file#command-line-options
+    extraArgs: []
+      # - --workers=10
+      # - --retry-interval-start=1s
+      # - --retry-interval-max=5m
+      # - --kube-api-qps=20
+      # - --kube-api-burst=40
     # -- Resizer resource requests and limits.
     # ref: https://kubernetes.io/docs/user-guide/compute-resources/
     resources:
@@ -184,6 +209,15 @@ controller:
     # -- Snapshotter arguments.
     # example: --feature-gates=CSIVolumeGroupSnapshot=true
     args: []
+    # -- Extra arguments for tuning csi-snapshotter performance.
+    # Useful for high-load environments with many snapshots.
+    # ref: https://github.com/kubernetes-csi/external-snapshotter?tab=readme-ov-file#command-line-options
+    extraArgs: []
+      # - --worker-threads=10
+      # - --retry-interval-start=1s
+      # - --retry-interval-max=5m
+      # - --kube-api-qps=20
+      # - --kube-api-burst=40
     # -- Snapshotter resource requests and limits.
     # ref: https://kubernetes.io/docs/user-guide/compute-resources/
     resources:
@@ -209,6 +243,10 @@ node:
       repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
       pullPolicy: IfNotPresent
       tag: v2.15.0
+    # -- Extra arguments for csi-node-driver-registrar.
+    # ref: https://github.com/kubernetes-csi/node-driver-registrar?tab=readme-ov-file#command-line-options
+    extraArgs: []
+      # - --health-port=9809
     # -- Node registrar resource requests and limits.
     # ref: https://kubernetes.io/docs/user-guide/compute-resources/
     resources:
@@ -244,6 +282,11 @@ livenessprobe:
     repository: registry.k8s.io/sig-storage/livenessprobe
     pullPolicy: IfNotPresent
     tag: v2.16.0
+  # -- Extra arguments for livenessprobe sidecar.
+  # ref: https://github.com/kubernetes-csi/livenessprobe?tab=readme-ov-file#command-line-options
+  extraArgs: []
+    # - --probe-timeout=3s
+    # - --health-port=9898
   # -- Failure threshold for livenessProbe
   failureThreshold: 5
   # -- Initial delay seconds for livenessProbe


### PR DESCRIPTION
# Pull Request

## What? (description)

Add `extraArgs` configuration option for CSI sidecar containers in the Helm chart:

- `controller.attacher.extraArgs`
- `controller.provisioner.extraArgs`
- `controller.resizer.extraArgs`
- `controller.snapshotter.extraArgs`
- `node.driverRegistrar.extraArgs`
- `livenessprobe.extraArgs`

Each field includes commented examples in `values.yaml` showing common tuning parameters like `--worker-threads`, `--retry-interval-start`, `--retry-interval-max`,
`--kube-api-qps`, and `--kube-api-burst`.

## Why? (reasoning)

In high-load environments with many PVCs, default sidecar settings can overwhelm the Proxmox API, causing timeouts and connectivity errors. This change allows users to tune
performance parameters (reduce parallelism, control retry behavior, adjust API rate limits) without forking the chart.

Closes #493

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)

> See `make help` for a description of the available targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Helm chart to support additional customizable arguments for CSI plugin components including attacher, provisioner, resizer, snapshotter, driver-registrar, and liveness-probe.
  * Added documented examples and tuning parameters for high-load scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->