### PR TITLE
fix: file storage type definition

### DIFF
--- a/pkg/csi/controller.go
+++ b/pkg/csi/controller.go
@@ -237,7 +237,7 @@ func (d *ControllerService) CreateVolume(ctx context.Context, request *csi.Creat
 	if storageConfig.Shared == 1 {
 		// https://pve.proxmox.com/wiki/Storage only block/local storage are supported
 		switch storageConfig.PluginType {
-		case "cifs", "pbs":
+		case "cifs", "pbs": // nolint: goconst
 			return nil, status.Error(codes.Internal, "error: shared storage type cifs, pbs are not supported")
 		}
 
@@ -277,7 +277,7 @@ func (d *ControllerService) CreateVolume(ctx context.Context, request *csi.Creat
 	}
 
 	format := ""
-	if storageConfig.PluginType == "dir" {
+	if getStorageLevel(storageConfig) == "file" {
 		format = "raw"
 		if params.StorageFormat == "qcow2" {
 			format = params.StorageFormat

--- a/pkg/csi/node.go
+++ b/pkg/csi/node.go
@@ -504,7 +504,7 @@ func (n *NodeService) NodeExpandVolume(_ context.Context, request *csi.NodeExpan
 	} else {
 		// comparing current volume size with the expected one
 		newSize := request.GetCapacityRange().GetRequiredBytes()
-		if err := blockdevice.RescanBlockDeviceGeometry(devicePath, volumePath, newSize); err != nil {
+		if err := blockdevice.RescanBlockDeviceGeometry(devicePath, volumePath, newSize); err != nil { // nolint:staticcheck
 			return nil, status.Errorf(codes.Internal, "Could not verify %q volume size: %v", volumeID, err)
 		}
 	}

--- a/pkg/csi/utils.go
+++ b/pkg/csi/utils.go
@@ -136,6 +136,16 @@ func getStorageContent(ctx context.Context, cl *goproxmox.APIClient, vol *volume
 	return nil, nil
 }
 
+func getStorageLevel(storage *proxmox.ClusterResource) string {
+	// see https://pve.proxmox.com/wiki/Storage
+	switch storage.PluginType {
+	case "dir", "nfs", "cifs", "cephfs", "btrfs": // nolint: goconst
+		return "file"
+	default:
+		return "block"
+	}
+}
+
 func getVolumeSize(ctx context.Context, cl *goproxmox.APIClient, vol *volume.Volume) (int64, error) {
 	st, err := getStorageContent(ctx, cl, vol)
 	if err != nil {


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

The cluster/resources API call does not return the storage type level. Use the storage plugin type to define it instead.

## Why? (reasoning)

https://github.com/sergelogvinov/proxmox-csi-plugin/issues/495

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of storage backend type during volume provisioning so volumes use the appropriate format for file-based backends (NFS, CIFS, BTRFS, CephFS) as well as block storage.

* **Chores**
  * Cleaned up and suppressed static analysis warnings in CSI controller and node components to improve code quality and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->