### PR TITLE
fix: handle unmount when node does not exist

### DIFF
--- a/.github/workflows/build-edge.yaml
+++ b/.github/workflows/build-edge.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v4.0.0
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: arm64
       - name: Set up docker buildx

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v4.0.0
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: arm64
       - name: Set up docker buildx

--- a/pkg/csi/controller.go
+++ b/pkg/csi/controller.go
@@ -52,10 +52,8 @@ const (
 
 	deviceNamePrefix = "scsi"
 
-	// resizeSizeBytes is the key for the volume context parameter to specify the new size in bytes after restore from snapshot
-	// we cannot change size offline, so we pass it via volume context
-	resizeSizeBytes = "resizeSizeBytes"
-	resizeRequired  = "resizeRequired"
+	// resizeRequired is the key for the volume context parameter to indicate whether resize is required after restore from snapshot
+	resizeRequired = "resizeRequired"
 )
 
 var controllerCaps = []csi.ControllerServiceCapability_RPC_Type{

--- a/pkg/csi/utils.go
+++ b/pkg/csi/utils.go
@@ -440,6 +440,10 @@ func attachVolume(ctx context.Context, cl *goproxmox.APIClient, id int, vol *vol
 func detachVolume(ctx context.Context, cl *goproxmox.APIClient, id int, vol *volume.Volume) error {
 	vm, err := cl.GetVMConfig(ctx, id)
 	if err != nil {
+		if errors.Is(err, goproxmox.ErrVirtualMachineNotFound) {
+			return nil
+		}
+
 		return fmt.Errorf("failed to get vm config: %v", err)
 	}
 
@@ -571,6 +575,10 @@ func waitDetachVolume(ctx context.Context, cl *goproxmox.APIClient, id int, vol 
 	err := retry.Constant(TaskTimeout*time.Second, retry.WithUnits(TaskStatusCheckInterval*time.Second)).Retry(func() error {
 		vm, err := cl.GetVMConfig(ctx, id)
 		if err != nil {
+			if errors.Is(err, goproxmox.ErrVirtualMachineNotFound) {
+				return nil
+			}
+
 			return fmt.Errorf("failed to get vm config: %v", err)
 		}
 


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

Catch the case where the VM was removed before the disk was unmounted.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of volume detachment by treating missing virtual machines as successful/no-op conditions.

* **Chores**
  * Updated CI build tooling to a newer, more stable setup.

* **Refactor**
  * Simplified volume metadata configuration by removing an unused size parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->