### PR TITLE
helm chart: Added option to set volumeBindingMode of storageclass

### DIFF
--- a/charts/proxmox-csi-plugin/Chart.yaml
+++ b/charts/proxmox-csi-plugin/Chart.yaml
@@ -18,7 +18,7 @@ maintainers:
     url: https://github.com/sergelogvinov
 #
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.6
+version: 0.5.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/proxmox-csi-plugin/templates/storageclass.yaml
+++ b/charts/proxmox-csi-plugin/templates/storageclass.yaml
@@ -13,7 +13,7 @@ metadata:
   {{- end }}
 provisioner: {{ $.Values.provisionerName }}
 allowVolumeExpansion: true
-volumeBindingMode: WaitForFirstConsumer
+volumeBindingMode: {{ default "WaitForFirstConsumer" $storage.volumeBindingMode }}
 reclaimPolicy: {{ default "Delete" $storage.reclaimPolicy }}
 parameters:
   {{- mustMergeOverwrite (default (dict) $storage.extraParameters) (include "storageClass.parameters" . | fromYaml) | toYaml | nindent 2 -}}

--- a/charts/proxmox-csi-plugin/values.yaml
+++ b/charts/proxmox-csi-plugin/values.yaml
@@ -71,6 +71,8 @@ config:
 storageClass: []
   # - name: proxmox-data-xfs
   #   storage: data
+  #   For ceph storage you should use volumeBindingMode Immediate, defaults to WaitForFirstConsumer
+  #   volumeBindingMode: WaitForFirstConsumer|Immediate
   #   reclaimPolicy: Delete
   #   fstype: ext4|xfs
   #


### PR DESCRIPTION
# Pull Request

Please consider the helm chart option to set the volumeBindingMode . We needed "Immediate" to make tghe provisioner go on with provisioning the volume of storagetype "ceph/rbd".




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-backend configurable volumeBindingMode for storage classes, defaulting to WaitForFirstConsumer.

* **Documentation**
  * Added guidance recommending Immediate for certain backends (e.g., Ceph) and documented the default behavior.

* **Chores**
  * Helm chart package version bumped for this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->