### PR TITLE
(feature) configurable controller VMID 

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -6,6 +6,10 @@ This file is used to configure the Proxmox CSI driver plugin.
 features:
   # Provider type
   provider: default|capmox
+  # Controller VM ID. Must be greater than 100.
+  # Default is 9999, which is a safe value that is unlikely to conflict with existing VMs.
+  # You can change it if needed, but make sure to choose a value that is not used by any existing VM in your Proxmox cluster.
+  controllerVMID: 9999
 
 clusters:
   # List of Proxmox clusters

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,17 +33,30 @@ import (
 // Provider specifies the provider. Can be 'default' or 'capmox'
 type Provider string
 
-// ProviderDefault is the default provider
-const ProviderDefault Provider = "default"
+const (
+	// ProviderDefault is the default provider
+	ProviderDefault Provider = "default"
 
-// ProviderCapmox is the Provider for capmox
-const ProviderCapmox Provider = "capmox"
+	// ProviderCapmox is the Provider for capmox
+	ProviderCapmox Provider = "capmox"
+)
+
+const (
+	// DefaultControllerVMID is the default VM ID used by the controller when none is specified.
+	DefaultControllerVMID = 9999
+
+	// MinControllerVMID is the minimum valid VM ID for the controller.
+	MinControllerVMID = 100
+)
 
 // ClustersFeatures specifies the features for the cloud provider.
 type ClustersFeatures struct {
 	// Provider specifies the provider to use. Can be 'default' or 'capmox'.
 	// Default is 'default'.
 	Provider Provider `yaml:"provider,omitempty"`
+	// ControllerVMID is the VM ID used by the controller for volume operations (e.g. volume naming).
+	// Default is 9999.
+	ControllerVMID int `yaml:"controllerVmID,omitempty"`
 }
 
 // ClustersConfig is proxmox multi-cluster cloud config.
@@ -59,6 +72,7 @@ var (
 	ErrAuthCredentialsMissing = errors.New("user, token or file credentials are required")
 	ErrInvalidAuthCredentials = errors.New("must specify one of user, token or file credentials, not multiple")
 	ErrInvalidCloudConfig     = errors.New("invalid cloud config")
+	ErrInvalidVMID            = errors.New("invalid VM ID, must be greater than 100")
 )
 
 // ReadCloudConfig reads cloud config from a reader.
@@ -95,6 +109,14 @@ func ReadCloudConfig(config io.Reader) (ClustersConfig, error) {
 
 	if cfg.Features.Provider == "" {
 		cfg.Features.Provider = ProviderDefault
+	}
+
+	if cfg.Features.ControllerVMID == 0 {
+		cfg.Features.ControllerVMID = DefaultControllerVMID
+	}
+
+	if cfg.Features.ControllerVMID <= MinControllerVMID {
+		return ClustersConfig{}, fmt.Errorf("invalid VM ID, must be greater than %d", MinControllerVMID)
 	}
 
 	return cfg, nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -115,7 +115,8 @@ clusters:
 `),
 			expected: &providerconfig.ClustersConfig{
 				Features: providerconfig.ClustersFeatures{
-					Provider: providerconfig.ProviderDefault,
+					Provider:       providerconfig.ProviderDefault,
+					ControllerVMID: providerconfig.DefaultControllerVMID,
 				},
 				Clusters: []*pxpool.ProxmoxCluster{
 					{
@@ -140,7 +141,8 @@ clusters:
 `),
 			expected: &providerconfig.ClustersConfig{
 				Features: providerconfig.ClustersFeatures{
-					Provider: providerconfig.ProviderDefault,
+					Provider:       providerconfig.ProviderDefault,
+					ControllerVMID: providerconfig.DefaultControllerVMID,
 				},
 				Clusters: []*pxpool.ProxmoxCluster{
 					{
@@ -167,7 +169,8 @@ clusters:
 `),
 			expected: &providerconfig.ClustersConfig{
 				Features: providerconfig.ClustersFeatures{
-					Provider: providerconfig.ProviderCapmox,
+					Provider:       providerconfig.ProviderCapmox,
+					ControllerVMID: providerconfig.DefaultControllerVMID,
 				},
 				Clusters: []*pxpool.ProxmoxCluster{
 					{

--- a/pkg/csi/controller.go
+++ b/pkg/csi/controller.go
@@ -48,8 +48,6 @@ import (
 )
 
 const (
-	vmID = 9999
-
 	deviceNamePrefix = "scsi"
 
 	// resizeRequired is the key for the volume context parameter to indicate whether resize is required after restore from snapshot
@@ -75,6 +73,7 @@ type ControllerService struct {
 	pxpool   *pxpool.ProxmoxPool
 	kclient  kubernetes.Interface
 	Provider csiconfig.Provider
+	vmID     int
 
 	storageCapacity *cache.Cache
 	vmLocks         *VMLocks
@@ -96,6 +95,7 @@ func NewControllerService(kclient kubernetes.Interface, cloudConfig string) (*Co
 		pxpool:   px,
 		kclient:  kclient,
 		Provider: cfg.Features.Provider,
+		vmID:     cfg.Features.ControllerVMID,
 	}
 
 	d.Init()
@@ -279,14 +279,14 @@ func (d *ControllerService) CreateVolume(ctx context.Context, request *csi.Creat
 		}
 	}
 
-	id := vmID
+	id := d.vmID
 
 	if params.Replicate {
 		if storageConfig.PluginType != "zfspool" {
 			return nil, status.Error(codes.Internal, "error: storage type is not zfs in replication mode")
 		}
 
-		id, err = prepareReplication(ctx, cl, zone, pvc)
+		id, err = prepareReplication(ctx, cl, zone, pvc, d.vmID)
 		if err != nil {
 			klog.ErrorS(err, "CreateVolume: failed to prepare replication", "cluster", region, "zone", zone)
 
@@ -425,7 +425,7 @@ func (d *ControllerService) DeleteVolume(ctx context.Context, request *csi.Delet
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	err = deleteReplication(ctx, cl, vol)
+	err = deleteReplication(ctx, cl, vol, d.vmID)
 	if err != nil {
 		klog.ErrorS(err, "DeleteVolume: failed to delete replication", "cluster", vol.Cluster(), "volumeID", vol.VolumeID())
 
@@ -539,7 +539,7 @@ func (d *ControllerService) ControllerPublishVolume(ctx context.Context, request
 	defer d.vmLocks.Unlock(n.GetNodeName())
 
 	if params.Replicate {
-		err = migrateReplication(ctx, cl, id, vol)
+		err = migrateReplication(ctx, cl, id, vol, d.vmID)
 		if err != nil {
 			klog.ErrorS(err, "ControllerPublishVolume: failed to migrate/sync replication", "cluster", vol.Cluster(), "volumeID", vol.VolumeID(), "vmID", id)
 
@@ -792,7 +792,7 @@ func (d *ControllerService) CreateSnapshot(ctx context.Context, request *csi.Cre
 		return nil, err
 	}
 
-	snapshotID := vol.CopyVolume(fmt.Sprintf("vm-%d-%s", vmID, name))
+	snapshotID := vol.CopyVolume(fmt.Sprintf("vm-%d-%s", d.vmID, name))
 
 	if params["zone"] != "" {
 		if storageConfig.Nodes != "" {

--- a/pkg/csi/utils.go
+++ b/pkg/csi/utils.go
@@ -192,7 +192,7 @@ func isVolumeAttached(vm *proxmox.VirtualMachineConfig, pvc string) (int, bool) 
 	return 0, false
 }
 
-func prepareReplication(ctx context.Context, cl *goproxmox.APIClient, node string, name string) (int, error) {
+func prepareReplication(ctx context.Context, cl *goproxmox.APIClient, node string, name string, vmID int) (int, error) {
 	vmr, err := cl.GetVMByFilter(ctx, func(r *proxmox.ClusterResource) (bool, error) {
 		return r.Name == name, nil
 	})
@@ -253,7 +253,7 @@ func createReplication(ctx context.Context, cl *goproxmox.APIClient, id int, vol
 	return nil
 }
 
-func migrateReplication(ctx context.Context, cl *goproxmox.APIClient, target int, vol *volume.Volume) error {
+func migrateReplication(ctx context.Context, cl *goproxmox.APIClient, target int, vol *volume.Volume, vmID int) error {
 	volid, err := strconv.Atoi(vol.VMID())
 	if err != nil {
 		return fmt.Errorf("failed to parse volumeID %s: %v", vol.VolumeID(), err)
@@ -310,7 +310,7 @@ func migrateReplication(ctx context.Context, cl *goproxmox.APIClient, target int
 	return nil
 }
 
-func deleteReplication(ctx context.Context, cl *goproxmox.APIClient, vol *volume.Volume) error {
+func deleteReplication(ctx context.Context, cl *goproxmox.APIClient, vol *volume.Volume, vmID int) error {
 	id, err := strconv.Atoi(vol.VMID())
 	if err != nil {
 		return fmt.Errorf("failed to parse volumeID %s: %v", vol.VolumeID(), err)


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

Suggested change for https://github.com/sergelogvinov/proxmox-csi-plugin/issues/561
## Why? (reasoning)

I would love to be able to easily identity volumes between clusters

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable controller VM ID for volume operations, snapshots, and replication (new config option, default 9999).

* **Bug Fixes / Validation**
  * Configuration now enforces a minimum VM ID (>100) and rejects smaller values with a clear error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->