### PR TITLE
fix: reset vol.Node() after checkVolume to prevent getVMByAttachedVolume from searching only a single node

### DIFF
--- a/pkg/csi/controller.go
+++ b/pkg/csi/controller.go
@@ -1096,6 +1096,10 @@ func (d *ControllerService) checkVolume(ctx context.Context, vol *volume.Volume)
 			}
 
 			klog.V(5).InfoS("checkVolume: determined node for volume", "cluster", vol.Cluster(), "volumeID", vol.VolumeID(), "node", n)
+			// Reset node to avoid pinning the volume to a specific node.
+			// When storage is shared across multiple nodes, callers like
+			// getVMByAttachedVolume need to search all nodes to find the VM.
+			vol.SetNode("")
 
 			return size, nil
 		}

--- a/pkg/csi/controller_test.go
+++ b/pkg/csi/controller_test.go
@@ -1087,6 +1087,23 @@ func (ts *configuredTestSuite) TestControllerExpandVolumeError() {
 				NodeExpansionRequired: true,
 			},
 		},
+		{
+			// The volume ID has no zone (cluster//<storage>/<disk>), so vol.Node() starts
+			// empty and checkVolume must iterate all nodes to find the disk. pvc-on-pve2
+			// only exists in pve-2's storage content, so checkVolume sets vol.Node()=pve-2.
+			// Without the fix, getVMByAttachedVolume only searches pve-2 and misses VM 100
+			// which runs on pve-1. A zoned volume ID (cluster-1/pve-1/...) would bypass
+			// this code path entirely and not catch the regression.
+			msg: "ExpandVolumeSharedStorageVMOnDifferentNode",
+			request: &proto.ControllerExpandVolumeRequest{
+				VolumeId:      "cluster-1//local-lvm/vm-9999-pvc-on-pve2",
+				CapacityRange: capRange,
+			},
+			expected: &proto.ControllerExpandVolumeResponse{
+				CapacityBytes:         100 * csi.GiB,
+				NodeExpansionRequired: true,
+			},
+		},
 	}
 
 	for _, testCase := range tests {

--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -292,6 +292,24 @@ func SetupMockResponders() {
 			})
 		},
 	)
+	// pvc-on-pve2 exists only on pve-2 and is attached to VM 100 running on pve-1.
+	// This simulates the shared-storage bug: checkVolume finds the disk on pve-2
+	// and (without the fix) pins vol.Node() to pve-2, causing getVMByAttachedVolume
+	// to miss VM 100 which runs on pve-1.
+	// Registered after the generic responder so it takes priority for pve-2.
+	httpmock.RegisterResponder(http.MethodGet, "https://127.0.0.1:8006/api2/json/nodes/pve-2/storage/local-lvm/content",
+		func(_ *http.Request) (*http.Response, error) {
+			return httpmock.NewJsonResponse(200, map[string]any{
+				"data": []proxmox.StorageContent{
+					{
+						Format: "raw",
+						Size:   uint64(csi.MinChunkSizeBytes),
+						Volid:  "local-lvm:vm-9999-pvc-on-pve2",
+					},
+				},
+			})
+		},
+	)
 	httpmock.RegisterResponder(http.MethodGet, `=~/nodes/\S+/storage/\S+/content`,
 		func(_ *http.Request) (*http.Response, error) {
 			return httpmock.NewJsonResponse(500, map[string]any{
@@ -346,6 +364,7 @@ func SetupMockResponders() {
 					"vmid":    100,
 					"scsi0":   "local-lvm:vm-100-disk-0,size=10G",
 					"scsi1":   "local-lvm:vm-9999-pvc-123,backup=0,iothread=1,wwn=0x5056432d49443031",
+					"scsi2":   "local-lvm:vm-9999-pvc-on-pve2,backup=0,iothread=1",
 					"smbios1": "uuid=11833f4c-341f-4bd3-aad7-f7abed000000",
 				},
 			})
@@ -390,6 +409,26 @@ func SetupMockResponders() {
 	)
 
 	httpmock.RegisterResponder("PUT", "https://127.0.0.1:8006/api2/json/nodes/pve-1/qemu/100/resize",
+		func(_ *http.Request) (*http.Response, error) {
+			return httpmock.NewJsonResponse(200, map[string]any{
+				"data": "",
+			})
+		},
+	)
+	// Shared storage volumes have an empty node; ResizeVMDisk resolves the node via Ping
+	httpmock.RegisterResponder("GET", "https://127.0.0.1:8006/api2/json/nodes//qemu/100/status/current",
+		func(_ *http.Request) (*http.Response, error) {
+			return httpmock.NewJsonResponse(200, map[string]any{
+				"data": proxmox.VirtualMachine{
+					VMID:   100,
+					Name:   "cluster-1-node-1",
+					Node:   "pve-1",
+					Status: "running",
+				},
+			})
+		},
+	)
+	httpmock.RegisterResponder("PUT", "https://127.0.0.1:8006/api2/json/nodes//qemu/100/resize",
 		func(_ *http.Request) (*http.Response, error) {
 			return httpmock.NewJsonResponse(200, map[string]any{
 				"data": "",


### PR DESCRIPTION
…

# Pull Request

## What? (description)
Reset vol.Node() to "" at the end of the shared-storage path in checkVolume, after the volume has been found and its size returned.

## Why? (reasoning)
See Issue #564. When a volume uses shared storage (available on multiple Proxmox nodes), checkVolume iterates over all nodes to locate the volume and temporarily sets vol.Node() to each candidate. On success it left vol.Node() set to whichever node happened to have the volume — not necessarily the node where the VM using it is running.

Callers that subsequently call getVMByAttachedVolume (i.e. ControllerExpandVolume and ControllerModifyVolume) are then only searching for VMs on that one node, causing ErrVirtualMachineNotFound even though the VM exists on a different node that also has access to the same shared storage.

Resetting vol.Node() to "" lets getVMByAttachedVolume fall back to querying all nodes for the storage, which is the correct behavior for shared storage.

Alternative approaches considered:
- Fix inside getVMByAttachedVolume: always search all nodes regardless of vol.Node(). Rejected because some callers intentionally constrain the search to a specific node.
- Return the node as an additional value from checkVolume: cleaner API, avoids mutating the volume, but requires updating all call sites and is a larger change.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where volumes remained pinned to the initial discovery node, preventing proper detection of attachments across multiple storage nodes.

* **Tests**
  * Added test coverage for volume expansion operations with zoneless volume identifiers.
  * Enhanced test infrastructure to model shared-storage scenarios where volumes exist on different nodes than their owning virtual machines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->