### PR TITLE
fix: reset vol.Node() in checkVolume for shared storage

### DIFF
--- a/pkg/csi/controller.go
+++ b/pkg/csi/controller.go
@@ -1077,16 +1077,22 @@ func (d *ControllerService) checkVolume(ctx context.Context, vol *volume.Volume)
 		}
 	}
 
+	// Check shared storage volumes across all nodes in the cluster
 	if vol.Node() == "" {
-		nodes, err := cl.GetNodesForStorage(ctx, vol.Storage())
+		probeVol, err := volume.NewVolumeFromVolumeID(vol.VolumeID())
+		if err != nil {
+			return 0, status.Error(codes.Internal, err.Error())
+		}
+
+		nodes, err := cl.GetNodesForStorage(ctx, probeVol.Storage())
 		if err != nil {
 			return 0, status.Error(codes.Internal, err.Error())
 		}
 
 		for _, n := range nodes {
-			vol.SetNode(n)
+			probeVol.SetNode(n)
 
-			size, err := getVolumeSize(ctx, cl, vol)
+			size, err := getVolumeSize(ctx, cl, probeVol)
 			if err != nil {
 				if err.Error() == ErrorNotFound {
 					continue
@@ -1101,12 +1107,6 @@ func (d *ControllerService) checkVolume(ctx context.Context, vol *volume.Volume)
 		}
 
 		return 0, status.Errorf(codes.NotFound, "volume %s not found in any node for storage %s", vol.VolumeID(), vol.Storage())
-
-		// node, err := getNodeForVolume(ctx, cl, vol)
-		// if err != nil {
-		// 	return 0, status.Error(codes.Internal, err.Error())
-		// }
-		// vol.SetNode(node)
 	}
 
 	size, err := getVolumeSize(ctx, cl, vol)

--- a/pkg/csi/controller_test.go
+++ b/pkg/csi/controller_test.go
@@ -1087,6 +1087,20 @@ func (ts *configuredTestSuite) TestControllerExpandVolumeError() {
 				NodeExpansionRequired: true,
 			},
 		},
+		{
+			// The volume ID has no zone (cluster//<storage>/<disk>), so vol.Node() starts
+			// empty and checkVolume must iterate all nodes to find the disk. vm-9999-volume-rbd.raw
+			// only exists in pve-2's storage content.
+			msg: "ExpandVolumeSharedStorageVMOnDifferentNode",
+			request: &proto.ControllerExpandVolumeRequest{
+				VolumeId:      "cluster-1//rbd/9999/vm-9999-volume-rbd.raw",
+				CapacityRange: capRange,
+			},
+			expected: &proto.ControllerExpandVolumeResponse{
+				CapacityBytes:         100 * csi.GiB,
+				NodeExpansionRequired: true,
+			},
+		},
 	}
 
 	for _, testCase := range tests {

--- a/pkg/csi/utils.go
+++ b/pkg/csi/utils.go
@@ -116,6 +116,10 @@ func getVMByAttachedVolume(ctx context.Context, cl *goproxmox.APIClient, vol *vo
 	}
 
 	if vm.VMID != 0 {
+		if vol.Node() == "" {
+			vol.SetNode(vm.Node)
+		}
+
 		return int(vm.VMID), lun, nil
 	}
 

--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -82,6 +82,16 @@ func SetupMockResponders() {
 						Status:     "available",
 					},
 					&proxmox.ClusterResource{
+						ID:         "storage/rbd",
+						Type:       "storage",
+						PluginType: "dir",
+						Node:       "pve-2",
+						Storage:    "rbd",
+						Content:    "images",
+						Shared:     1,
+						Status:     "available",
+					},
+					&proxmox.ClusterResource{
 						ID:         "storage/zfs",
 						Type:       "storage",
 						PluginType: "zfspool",
@@ -371,6 +381,7 @@ func SetupMockResponders() {
 					"vmid":    101,
 					"scsi0":   "local-lvm:vm-101-disk-0,size=10G",
 					"scsi1":   "local-lvm:vm-101-disk-1,size=1G",
+					"scsi2":   "rbd:9999/vm-9999-volume-rbd.raw,backup=0,iothread=1",
 					"scsi3":   "local-lvm:vm-101-disk-2,size=1G",
 					"smbios1": "uuid=11833f4c-341f-4bd3-aad7-f7abed000001",
 				},
@@ -390,6 +401,14 @@ func SetupMockResponders() {
 	)
 
 	httpmock.RegisterResponder("PUT", "https://127.0.0.1:8006/api2/json/nodes/pve-1/qemu/100/resize",
+		func(_ *http.Request) (*http.Response, error) {
+			return httpmock.NewJsonResponse(200, map[string]any{
+				"data": "",
+			})
+		},
+	)
+
+	httpmock.RegisterResponder("PUT", "https://127.0.0.1:8006/api2/json/nodes/pve-2/qemu/101/resize",
 		func(_ *http.Request) (*http.Response, error) {
 			return httpmock.NewJsonResponse(200, map[string]any{
 				"data": "",


### PR DESCRIPTION
…

# Pull Request

## What? (description)
Reset vol.Node() to "" at the end of the shared-storage path in checkVolume, after the volume has been found and its size returned.

## Why? (reasoning)
See Issue #564. When a volume uses shared storage (available on multiple Proxmox nodes), checkVolume iterates over all nodes to locate the volume and temporarily sets vol.Node() to each candidate. On success it left vol.Node() set to whichever node happened to have the volume — not necessarily the node where the VM using it is running.

Callers that subsequently call getVMByAttachedVolume (i.e. ControllerExpandVolume and ControllerModifyVolume) are then only searching for VMs on that one node, causing ErrVirtualMachineNotFound even though the VM exists on a different node that also has access to the same shared storage.

Resetting vol.Node() to "" lets getVMByAttachedVolume fall back to querying all nodes for the storage, which is the correct behavior for shared storage.

Alternative approaches considered:
- Fix inside getVMByAttachedVolume: always search all nodes regardless of vol.Node(). Rejected because some callers intentionally constrain the search to a specific node.
- Return the node as an additional value from checkVolume: cleaner API, avoids mutating the volume, but requires updating all call sites and is a larger change.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shared-storage volume capacity probing so it no longer impacts later volume discovery and sizing.
  * When resolving an attached VM, the system now correctly fills in the missing node on the volume before proceeding.

* **Tests**
  * Added a regression test for shared-storage volume expansion when the volume ID omits zone information.
  * Updated cluster HTTP mocks to more accurately reflect resize behavior on the expected node and VM devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->