### PR TITLE
fix: pvc migration

### DIFF
--- a/cmd/pvecsictl/migrate.go
+++ b/cmd/pvecsictl/migrate.go
@@ -86,6 +86,10 @@ func (c *migrateCmd) runMigration(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get resources: %v", err)
 	}
 
+	if kubePV.Spec.CSI == nil || kubePV.Spec.CSI.Driver != csi.DriverName {
+		return fmt.Errorf("persistentvolume %s is not provisioned by Proxmox CSI driver", kubePV.Name)
+	}
+
 	vol, err := volume.NewVolumeFromVolumeID(kubePV.Spec.CSI.VolumeHandle)
 	if err != nil {
 		return fmt.Errorf("failed to parse volume ID: %v", err)
@@ -141,7 +145,7 @@ func (c *migrateCmd) runMigration(cmd *cobra.Command, args []string) error {
 
 			logger.Infof("cordoning nodes: %s", strings.Join(cordonedNodes, ","))
 
-			if _, err = tools.CondonNodes(ctx, c.kclient, cordonedNodes); err != nil {
+			if cordonedNodes, err = tools.CondonNodes(ctx, c.kclient, cordonedNodes); err != nil {
 				return fmt.Errorf("failed to cordon nodes: %v", err)
 			}
 

--- a/cmd/pvecsictl/utils.go
+++ b/cmd/pvecsictl/utils.go
@@ -67,6 +67,8 @@ func replacePVTopology(
 	newPVC.ObjectMeta.ResourceVersion = ""
 	delete(newPVC.ObjectMeta.Annotations, csi.DriverName+"/migrate")
 	delete(newPVC.ObjectMeta.Annotations, csi.DriverName+"/migrate-node")
+	newPVC.ObjectMeta.DeletionTimestamp = nil
+	newPVC.ObjectMeta.DeletionGracePeriodSeconds = nil
 	newPVC.Status = corev1.PersistentVolumeClaimStatus{}
 	newPVC.Spec.Resources.Requests = corev1.ResourceList{
 		corev1.ResourceStorage: pvc.Status.Capacity[corev1.ResourceStorage],
@@ -77,6 +79,8 @@ func replacePVTopology(
 	newPV.ObjectMeta.ResourceVersion = ""
 	delete(newPV.ObjectMeta.Annotations, csi.DriverName+"/migrate")
 	delete(newPV.ObjectMeta.Annotations, csi.DriverName+"/migrate-node")
+	newPV.ObjectMeta.DeletionTimestamp = nil
+	newPV.ObjectMeta.DeletionGracePeriodSeconds = nil
 	newPV.Spec.ClaimRef = nil
 	newPV.Status = corev1.PersistentVolumeStatus{}
 	newPV.Spec.CSI.VolumeHandle = volume.NewVolume(vol.Region(), node, vol.Storage(), vol.Disk()).VolumeID()

--- a/pkg/tools/kubernetes/pv.go
+++ b/pkg/tools/kubernetes/pv.go
@@ -95,6 +95,14 @@ func PVCCreateOrUpdate(
 
 // PVWaitDelete waits for the specified PersistentVolume to be deleted.
 func PVWaitDelete(ctx context.Context, clientset *clientkubernetes.Clientset, pvName string) error {
+	// We reuse PV name for change nodeSelector, but some comtrollers may modify PV on deletion event.
+	// So we need to wait after PV deletion before creating new PV with the same name.
+	select {
+	case <-time.After(5 * time.Second):
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
 	if _, err := clientset.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{}); err != nil {
 		if errors.IsNotFound(err) {
 			return nil


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

Enhance migration logic and handle deletion timestamps for PVCs and PVs

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed forced PersistentVolume migrations where the updated cordoned node list was not retained, improving later logging and uncordon behavior.

* **Improvements**
  * Added validation to only proceed when the target PersistentVolume is Proxmox CSI–provisioned (rejects missing CSI spec or mismatched CSI driver).
  * Improved PersistentVolume deletion reliability by introducing a short pre-wait before the existing deletion wait logic.
  * Cleared final deletion-related metadata on replacement PV/PVC objects during topology replacement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->