### PR TITLE
docs: disk not found.

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -57,6 +57,18 @@ spec:
 
 The disk name is `vm-100-disk-1`, and the storage class name is `proxmox-zfs`.
 
+## Device is not found error
+
+In rare cases, you may see the following error in the pod events:
+
+```shell
+MountVolume.MountDevice failed for volume "pvc-a5aed967-e96a-482a-a12f-212f81b9a1f8":
+rpc error: code = InvalidArgument desc = device /dev/disk/by-id/wwn-0x5056432d49443032 is not found
+```
+
+This error occurs in some Intel architectures with SCSI controller `VirtIO SCSI Single`, and the disk is not visible in Linux.
+The solution is to change the SCSI controller to `VirtIO SCSI` in the Proxmox VM configuration.
+
 ## How to change encrypted disk secret key?
 
 The secret key cannot be change through kubernetes API, but you can use the following instructions.


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

I've had the same issue on specific intel machine i7-6700. Talos linux (dmesg) shows that block device was attached, but Talos itself does not see the block device talosctl get disks.

In my opinion, the issue is likely in the virtual SCSI device implementation on a specific CPU architecture. I haven't seen this problem on AMD systems.
Try changing the SCSI controller to VirtIO SCSI (instead of VirtIO SCSI Single), which should work correctly.

fix #585

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new FAQ entry for “Device is not found” errors.
  * Includes common symptoms, likely conditions where it appears, and the recommended workaround for affected virtual machines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->