### PR TITLE
feat: allow discard to be set without ssd emulation

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -35,6 +35,7 @@ parameters:
 
   ## Optional: Proxmox csi options
   cache: directsync|none|writeback|writethrough
+  discard: on|ignore
   ssd: "true|false"
 
   ## Optional: Proxmox disk speed limit
@@ -86,6 +87,11 @@ parameters:
   ## Optional: Backup disk with VM
   backup: "true"
 
+  ## Optional: TRIM/UNMAP pass-through
+  ## On a running VM, Proxmox queues this change as pending, so UNMAP keeps
+  ## being ignored until the VM is next started.
+  discard: "on"
+
   ## Optional: Zone replication
   replicateSchedule: "*/30"
   replicateZones: "rnd-1,rnd-2"
@@ -112,6 +118,7 @@ metadata:
 * `storageFormat` - disk format: `raw`, `qcow2` [Official documentation](https://pve.proxmox.com/wiki/Storage)
 
 * `cache` - qemu cache param: `directsync`, `none`, `writeback`, `writethrough` [Official documentation](https://pve.proxmox.com/wiki/Performance_Tweaks)
+* `discard` - qemu discard param: `on`, `ignore`. Enables TRIM/UNMAP pass-through so freed blocks are released by the underlying storage. Useful on rotational disks, where `ssd` would be inaccurate. Defaults to `on` when `ssd` is true, an explicit value is never overridden. When set through a `VolumeAttributesClass` on a running VM, Proxmox queues the change as pending and qemu keeps ignoring UNMAP until the VM is next started.
 * `ssd` - set true if SSD/NVME disk, which enables both SSD emulation *and* Discard options in the attached Proxmox disk
 
 * `diskIOPS` - maximum r/w I/O in operations per second

--- a/pkg/csi/parameters.go
+++ b/pkg/csi/parameters.go
@@ -32,6 +32,9 @@ const (
 	StorageFormatKey = "storageFormat"
 	// StorageCacheKey is the cache type, can be one of "directsync", "none", "writeback", "writethrough"
 	StorageCacheKey = "cache"
+	// StorageDiscardKey enables TRIM/UNMAP pass-through, can be one of "on", "ignore".
+	// Setting ssd implies "on", this key allows it without SSD emulation.
+	StorageDiscardKey = "discard"
 	// StorageSSDKey is it ssd disk
 	StorageSSDKey = "ssd"
 
@@ -58,7 +61,7 @@ type StorageParameters struct {
 	AIO            string `json:"aio,omitempty"            cfg:"aio"`
 	Backup         *bool  `json:"backup,omitempty"         cfg:"backup"`
 	Cache          string `json:"cache,omitempty"          cfg:"cache"`
-	Discard        string `json:"-"                        cfg:"discard,omitempty"`
+	Discard        string `json:"discard,omitempty"        cfg:"discard,omitempty"`
 	IOThread       bool   `json:"iothread"                 cfg:"iothread,omitempty"`
 	IopsRead       *int   `json:"-"                        cfg:"iops_rd,omitempty"`
 	IopsWrite      *int   `json:"-"                        cfg:"iops_wr,omitempty"`
@@ -84,13 +87,14 @@ type StorageParameters struct {
 // json - tags are used to map the struct to the Kubernetes resource
 // cfg  - tags are used to map the struct to the Proxmox API
 type ModifyVolumeParameters struct {
-	Backup         *bool `json:"backup,omitempty"         cfg:"backup"`
-	IopsRead       *int  `json:"-"                        cfg:"iops_rd,omitempty"`
-	IopsWrite      *int  `json:"-"                        cfg:"iops_wr,omitempty"`
-	ReadSpeedMbps  *int  `json:"-"                        cfg:"mbps_rd,omitempty"`
-	WriteSpeedMbps *int  `json:"-"                        cfg:"mbps_wr,omitempty"`
-	Iops           *int  `json:"diskIOPS,omitempty"`
-	SpeedMbps      *int  `json:"diskMBps,omitempty"`
+	Backup         *bool   `json:"backup,omitempty"         cfg:"backup"`
+	Discard        *string `json:"discard,omitempty"        cfg:"discard,omitempty"`
+	IopsRead       *int    `json:"-"                        cfg:"iops_rd,omitempty"`
+	IopsWrite      *int    `json:"-"                        cfg:"iops_wr,omitempty"`
+	ReadSpeedMbps  *int    `json:"-"                        cfg:"mbps_rd,omitempty"`
+	WriteSpeedMbps *int    `json:"-"                        cfg:"mbps_wr,omitempty"`
+	Iops           *int    `json:"diskIOPS,omitempty"`
+	SpeedMbps      *int    `json:"diskMBps,omitempty"`
 
 	ReplicateSchedule string `json:"replicateSchedule,omitempty"`
 }
@@ -108,7 +112,8 @@ func ExtractParameters(parameters map[string]string) (StorageParameters, error) 
 		return p, err
 	}
 
-	if p.SSD != nil && *p.SSD {
+	// SSD emulation implies discard, unless discard was set explicitly.
+	if p.Discard == "" && p.SSD != nil && *p.SSD {
 		p.Discard = "on"
 	}
 

--- a/pkg/csi/parameters_test.go
+++ b/pkg/csi/parameters_test.go
@@ -62,6 +62,34 @@ func Test_ExtractAndDefaultParameters(t *testing.T) {
 			},
 		},
 		{
+			msg: "discard without ssd emulation",
+			params: map[string]string{
+				csi.StorageIDKey:      "local-lvm",
+				csi.StorageDiscardKey: "on",
+			},
+			storage: csi.StorageParameters{
+				StorageID: "local-lvm",
+				Backup:    ptr.Ptr(false),
+				IOThread:  true,
+				Discard:   "on",
+			},
+		},
+		{
+			msg: "explicit discard is not overridden by ssd",
+			params: map[string]string{
+				csi.StorageIDKey:      "local-lvm",
+				csi.StorageSSDKey:     "true",
+				csi.StorageDiscardKey: "ignore",
+			},
+			storage: csi.StorageParameters{
+				StorageID: "local-lvm",
+				Backup:    ptr.Ptr(false),
+				IOThread:  true,
+				SSD:       ptr.Ptr(true),
+				Discard:   "ignore",
+			},
+		},
+		{
 			msg: "disk limits",
 			params: map[string]string{
 				csi.StorageIDKey:       "local-lvm",
@@ -292,6 +320,19 @@ func Test_MergeMap(t *testing.T) {
 				"storage":   "lvm",
 				"ssd":       "true",
 				"blockSize": "1024",
+			},
+		},
+		{
+			msg: "Discard param",
+			storage: csi.ModifyVolumeParameters{
+				Discard: ptr.Ptr("on"),
+			},
+			params: map[string]string{
+				"storage": "lvm",
+			},
+			expected: map[string]string{
+				"discard": "on",
+				"storage": "lvm",
 			},
 		},
 		{


### PR DESCRIPTION
# Pull Request

## What? (description)

Expose `discard` as a storage class parameter in its own right, instead of only as a side effect of `ssd`.

- `StorageParameters.Discard` becomes readable from the storage class (`json:"-"` -> `json:"discard,omitempty"`), with a new `StorageDiscardKey` constant.
- `ModifyVolumeParameters` gains `Discard`, so the option can also be applied to an existing volume through a `VolumeAttributesClass`.
- `ssd: true` still implies `discard=on`, but no longer overrides an explicit value, so `discard: ignore` becomes expressible.
- `docs/options.md` documents the parameter in both the StorageClass and the VolumeAttributesClass sections.

## Why? (reasoning)

Today `discard` can only be turned on by setting `ssd: true`, which also enables SSD emulation. That is a problem on rotational storage: the guest is told the device is non-rotational and selects I/O scheduling and readahead tuned for flash, when the only thing wanted is space reclamation.

The two are unrelated at the qemu level. On a file-backed storage the guest UNMAP reaches qemu, which punches holes in the image, and the host filesystem releases the extents. No TRIM command ever reaches the physical drive, so `discard` is just as valid on spinning disks.

This is a known source of confusion: #509 was merged specifically to document that `ssd` "doesn't just control SSD emulation, but *also* the Discard option". #425 asked for a way to set discard and was answered with `mountOptions: [discard]`, which does not work on directory storage, see the measurement below.

### Measured on real hardware, on the same volume before and after

A single-node cluster, Proxmox VE 9.2.5, Kubernetes 1.34.10, `dir` storage on four HGST HUS724020ALA640 (`ROTA=1`, 7200rpm SATA), raw images. The volume is a real workload volume, `plex/transmission-config`, holding 16 MiB of live data in a 1 GiB image.

**Before, without `discard=on`.** The device already advertises discard support (`DISC-GRAN=4K`) and `fstrim` reports success, but nothing is released, because qemu runs with `discard=ignore`:

```
# fstrim -v .../pvc-f52d9351-.../mount
.../mount: 944.9 MiB (990826496 bytes) trimmed
# du -h vm-9999-pvc-f52d9351-....raw
802M   before
802M   after
```

**After, with this patch.** A `VolumeAttributesClass` carrying `discard: "on"` and no `ssd`, applied to the existing PVC. The controller wrote the option without detaching the volume:

```
scsi9: local:9999/vm-9999-pvc-f52d9351-....raw,backup=0,cache=none,discard=on,iothread=1,size=1G,wwn=0x5056432d49443039
```

Same `fstrim`, same volume, a few hours later:

```
# fstrim -v .../mount
.../mount: 949.7 MiB (995811328 bytes) trimmed
# du -h vm-9999-pvc-f52d9351-....raw
802M   before
 73M   after
```

**729 MiB returned to the host.** Same volume, same host, same storage, same plugin version; the only variable is `discard=on`. Data intact, the guest filesystem still reports its 16 MiB used and the application's files are untouched.

Note that the figure `fstrim` prints is nearly identical in both runs and means nothing on its own. Only the image allocation shows whether anything was actually released.

On the cluster this came from, roughly 287 GiB is stranded this way across nine volumes.

### One caveat worth documenting

Applying the class to a *running* VM writes the option into the config, but Proxmox queues it under `[PENDING]`:

```
$ qm pending 111
cur scsi9: ...,cache=none,iothread=1,...
new scsi9: ...,cache=none,discard=on,iothread=1,...
```

qemu only picks the option up when the disk is started, so the change takes effect at the next `qm reboot`, not immediately. `ControllerModifyVolume` itself behaves correctly and detaches nothing; this is a Proxmox constraint rather than a plugin one, but a user applying a `VolumeAttributesClass` would reasonably expect it to be effective right away.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable) — relates to #425, and to the documentation clarified in #509
- [x] you included tests (if applicable) — three cases in `parameters_test.go`: discard without ssd, explicit discard not overridden by ssd, and discard through `ModifyVolumeParameters`
- [x] you ran conformance (`make conformance`) — 10/10 PASS, including DCO and the single-commit rule
- [x] you linted your code (`make lint`) — 0 issues
- [x] you ran unit tests (`make unit`) — all packages pass
- [x] I disclosed AI usage honestly (if applicable) — the patch and this description were written with Claude Code. I reviewed the change, ran the checks, and ran the hardware measurements above on my own cluster. I stand behind the content.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the `discard` parameter (TRIM/UNMAP) for StorageClasses and VolumeAttributesClasses.
  - Supports `discard` in volume modifications and passes through to the underlying storage configuration.
  - Automatically defaults `discard` to `on` when SSD emulation is enabled, unless `discard` is explicitly set.

- **Documentation**
  - Documented `discard` options (`on|ignore`), including guidance for TRIM/UNMAP behavior (including “pending until VM restart” details).

- **Tests**
  - Added coverage for `discard` extraction, defaulting, and parameter merge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->