### PR TITLE
fix: verify volume attachment status

### DIFF
--- a/pkg/csi/utils.go
+++ b/pkg/csi/utils.go
@@ -418,8 +418,14 @@ func attachVolume(ctx context.Context, cl *goproxmox.APIClient, id int, vol *vol
 					return nil, fmt.Errorf("unable to attach disk: %v, options=%+v", err, vmOptions)
 				}
 
-				if err := task.WaitFor(ctx, 5*60); err != nil {
-					return nil, fmt.Errorf("unable to attach virtual machine disk: %w", err)
+				if task != nil {
+					if err := task.WaitFor(ctx, 5*60); err != nil {
+						return nil, fmt.Errorf("unable to attach virtual machine disk: %w", err)
+					}
+
+					if task.IsFailed {
+						return nil, fmt.Errorf("unable to attach virtual machine disk: %s", task.ExitStatus)
+					}
 				}
 
 				if err := waitAttachVolume(ctx, cl, id, vol); err != nil {
@@ -460,6 +466,10 @@ func detachVolume(ctx context.Context, cl *goproxmox.APIClient, id int, vol *vol
 		if task != nil {
 			if err := task.WaitFor(ctx, 5*60); err != nil {
 				return fmt.Errorf("unable to detach virtual machine disk: %w", err)
+			}
+
+			if task.IsFailed {
+				return fmt.Errorf("unable to detach virtual machine disk: %s", task.ExitStatus)
 			}
 		}
 	}


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

Add an additional check to ensure the block device is successfully attached or detached.

## Why? (reasoning)

close #621

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you ran unit tests (`make unit`)
- [ ] I disclosed AI usage honestly (if applicable)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volume attachment and detachment operations to detect asynchronous task failures.
  * Added clearer error reporting when these operations complete unsuccessfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->