### PR TITLE
fix: support lvm volume chains

### DIFF
--- a/pkg/csi/controller.go
+++ b/pkg/csi/controller.go
@@ -233,6 +233,8 @@ func (d *ControllerService) CreateVolume(ctx context.Context, request *csi.Creat
 		return nil, status.Errorf(codes.Internal, "failed to get proxmox storage config: %v", err)
 	}
 
+	klog.V(5).InfoS("CreateVolume: storage config", "storage", storageConfig)
+
 	topology := []*csi.Topology{
 		{
 			Segments: map[string]string{
@@ -307,6 +309,12 @@ func (d *ControllerService) CreateVolume(ctx context.Context, request *csi.Creat
 	}
 
 	format := ""
+
+	// LVM Snapshots as Volume-Chain are a technology preview.
+	if storageConfig.PluginType == "lvm" && params.StorageFormat == "qcow2" {
+		format = params.StorageFormat
+	}
+
 	if getStorageLevel(storageConfig) == "file" {
 		format = "raw"
 		if params.StorageFormat == "qcow2" {


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

Allow qcow2-style volume names on the LVM storage backend.

This is required for the Proxmox "Snapshots as Volume-Chain" feature, where snapshot-backed volumes are referenced by qcow2-compatible names instead of traditional LVM volume identifiers.

## Why? (reasoning)

close #619

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you ran unit tests (`make unit`)
- [ ] I disclosed AI usage honestly (if applicable)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the requested QCOW2 format when creating volumes with LVM storage.
  * Improved logging of the resolved storage configuration during volume creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->