### PR TITLE
fix: rbac for snapshot

### DIFF
--- a/charts/proxmox-csi-plugin/Chart.yaml
+++ b/charts/proxmox-csi-plugin/Chart.yaml
@@ -18,7 +18,7 @@ maintainers:
     url: https://github.com/sergelogvinov
 #
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.11
+version: 0.5.12
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/proxmox-csi-plugin/README.md
+++ b/charts/proxmox-csi-plugin/README.md
@@ -1,6 +1,6 @@
 # proxmox-csi-plugin
 
-![Version: 0.5.11](https://img.shields.io/badge/Version-0.5.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.20.0](https://img.shields.io/badge/AppVersion-v0.20.0-informational?style=flat-square)
+![Version: 0.5.12](https://img.shields.io/badge/Version-0.5.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.20.0](https://img.shields.io/badge/AppVersion-v0.20.0-informational?style=flat-square)
 
 Container Storage Interface plugin for Proxmox
 

--- a/charts/proxmox-csi-plugin/templates/controller-clusterrole.yaml
+++ b/charts/proxmox-csi-plugin/templates/controller-clusterrole.yaml
@@ -41,7 +41,7 @@ rules:
 
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch", "update"]
 
 {{- if .Values.controller.snapshotter.enabled }}
   - apiGroups: ["snapshot.storage.k8s.io"]

--- a/docs/deploy/proxmox-csi-plugin.yml
+++ b/docs/deploy/proxmox-csi-plugin.yml
@@ -17,7 +17,7 @@ metadata:
   name: proxmox-csi-plugin-controller
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.5.11
+    helm.sh/chart: proxmox-csi-plugin-0.5.12
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.20.0"
@@ -31,7 +31,7 @@ metadata:
   name: proxmox-csi-plugin-node
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.5.11
+    helm.sh/chart: proxmox-csi-plugin-0.5.12
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.20.0"
@@ -74,7 +74,7 @@ metadata:
   name: proxmox-csi-plugin-controller
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.5.11
+    helm.sh/chart: proxmox-csi-plugin-0.5.12
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.20.0"
@@ -115,7 +115,7 @@ rules:
 
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch", "update"]
 
 ---
 # Source: proxmox-csi-plugin/templates/node-clusterrole.yaml
@@ -125,7 +125,7 @@ metadata:
   name: proxmox-csi-plugin-node
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.5.11
+    helm.sh/chart: proxmox-csi-plugin-0.5.12
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.20.0"
@@ -145,7 +145,7 @@ kind: ClusterRoleBinding
 metadata:
   name: proxmox-csi-plugin-controller
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.5.11
+    helm.sh/chart: proxmox-csi-plugin-0.5.12
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.20.0"
@@ -182,7 +182,7 @@ metadata:
   name: proxmox-csi-plugin-controller
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.5.11
+    helm.sh/chart: proxmox-csi-plugin-0.5.12
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.20.0"
@@ -210,7 +210,7 @@ metadata:
   name: proxmox-csi-plugin-controller
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.5.11
+    helm.sh/chart: proxmox-csi-plugin-0.5.12
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.20.0"
@@ -232,7 +232,7 @@ metadata:
   name: proxmox-csi-plugin-node
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.5.11
+    helm.sh/chart: proxmox-csi-plugin-0.5.12
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.20.0"
@@ -379,7 +379,7 @@ metadata:
   name: proxmox-csi-plugin-controller
   namespace: csi-proxmox
   labels:
-    helm.sh/chart: proxmox-csi-plugin-0.5.11
+    helm.sh/chart: proxmox-csi-plugin-0.5.12
     app.kubernetes.io/name: proxmox-csi-plugin
     app.kubernetes.io/instance: proxmox-csi-plugin
     app.kubernetes.io/version: "v0.20.0"


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

VolumeSnapshot requires additional permissions to check the finalizer.

## Why? (reasoning)

close https://github.com/sergelogvinov/proxmox-csi-plugin/issues/629

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you ran unit tests (`make unit`)
- [ ] I disclosed AI usage honestly (if applicable)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for updating volume snapshots through the storage controller.

- **Chores**
  - Updated the Helm chart release version to 0.5.12.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->